### PR TITLE
feat: add sanity schemas and refactor sections

### DIFF
--- a/src/app/(site)/about/page.js
+++ b/src/app/(site)/about/page.js
@@ -74,21 +74,24 @@ export default function AboutPage() {
     return (
         <div className="w-full bg-[#373737]">
             {/* Hero section with background image */}
-            <section className="w-full bg-orange-400 py-30 overflow-x-clip">
+            <section className="w-full bg-[#cb6d0d] py-30 overflow-x-clip">
                 <div className="mx-auto max-w-7xl px-6 md:px-12">
                     <div className="flex gap-8">
                         <h1 className="text-white text-xl font-bold [writing-mode:vertical-rl] text-nowrap shrink-0">
                             VỀ CHÚNG TÔI
                         </h1>
 
-                        <div className="grid min-w-0 grid-cols-1 md:grid-cols-2 gap-12 border-l border-white pl-4">
+                        <div className="grid min-w-0 grid-cols-1 lg:grid-cols-2 gap-12 border-l border-white pl-4">
                             {/* Cột text */}
                             <div className="relative min-w-0 px-10">
-                                <h2 className="text-white text-5xl mb-8">
-                                    CÔNG TY TNHH NHÀ ĐẸP QUẢNG NAM
-                                </h2>
+                                <p className="text-white text-4xl">
+                                    CÔNG TY TNHH
+                                </p>
+                                <p className="text-white text-4xl whitespace-nowrap">
+                                    NHÀ ĐẸP QUẢNG NAM
+                                </p>
                                 <br/>
-                                <p className="text-white text-lg">Công ty TNHH NHÀ ĐẸP QUẢNG NAM do KTS Nguyên Tương
+                                <p className="text-white text-lg text-justify">Công ty TNHH NHÀ ĐẸP QUẢNG NAM do KTS Nguyên Tương
                                     thành
                                     lập. Với sự nhiệt huyết cùng đội
                                     ngũ nhân sự trẻ trung và năng động, NĐQN mong muốn mang đến cho các bạn nhưng bản
@@ -96,7 +99,7 @@ export default function AboutPage() {
                                     kế đa dạng phong cách, mới lạ và tất nhiên sẽ phù hợp với từng đối tượng.
                                 </p>
                                 <br/>
-                                <p className="text-white text-lg">Với ước mơ tạo ra những ngôi nhà thật đẹp chàng kĩ
+                                <p className="text-white text-lg text-justify">Với ước mơ tạo ra những ngôi nhà thật đẹp chàng kĩ
                                     sư
                                     trẻ
                                     Nguyên Tương Tổng Giám Đốc tại công ty Nhà Đẹp Quảng Nam chia sẻ.
@@ -106,7 +109,7 @@ export default function AboutPage() {
                                     nơi gia đình sum vầy, nơi nuôi dưỡng những khoảnh khắc hạnh phúc."
                                 </p>
                                 <br/>
-                                <p className="text-white text-lg">Công ty TNHH NHÀ ĐẸP QUẢNG NAM do KTS Nguyên Tương
+                                <p className="text-white text-lg text-justify">Công ty TNHH NHÀ ĐẸP QUẢNG NAM do KTS Nguyên Tương
                                     thành
                                     lập. Với sự nhiệt huyết cùng đội
                                     ngũ nhân sự trẻ trung và năng động, NĐQN mong muốn mang đến cho các bạn nhưng bản
@@ -114,7 +117,7 @@ export default function AboutPage() {
                                     kế đa dạng phong cách, mới lạ và tất nhiên sẽ phù hợp với từng đối tượng.
                                 </p>
                                 <br/>
-                                <p className="text-white text-lg">Với ước mơ tạo ra những ngôi nhà thật đẹp chàng kĩ
+                                <p className="text-white text-lg text-justify">Với ước mơ tạo ra những ngôi nhà thật đẹp chàng kĩ
                                     sư
                                     trẻ
                                     Nguyên Tương Tổng Giám Đốc tại công ty Nhà Đẹp Quảng Nam chia sẻ.

--- a/src/app/(site)/about/page.js
+++ b/src/app/(site)/about/page.js
@@ -3,178 +3,40 @@ import Image from "next/image";
 import {useEffect, useState} from "react";
 import {CreditCard, Lock, ShieldUser} from "lucide-react";
 import animateOnObserve from "@/lib/animateOnObserve";
-import {fancyFont} from "@/app/fonts";
 import Commitments from "@/components/Commitments";
 import CoreValues from "@/components/CoreValues";
+import AboutHeroSection from "@/components/AboutHeroSection";
+import TeamSection from "@/components/TeamSection";
+import {client} from "@/sanity/lib/client";
+import {aboutPageQuery} from "@/sanity/lib/queries";
 
 export default function AboutPage() {
-    const [expanded, setExpanded] = useState(false);
-    const aboutShort =
-        <div className="text-white text-lg">
-            <p>
-                Với ước mơ tạo ra những ngôi nhà thật đẹp chàng kĩ sư trẻ Nguyên Tương Tổng Giám Đốc tại công ty Nhà Đẹp
-                Quảng Nam chia sẻ.
-            </p>
-            <br/>
-            <blockquote className="text-2xl italic mb-6 text-center md:text-left">
-                "Chúng tôi không chỉ đơn thuần xây dựng những công trình, mà còn kiến tạo nên những tổ ấm
-                - nơi gia đình sum vầy, nơi nuôi dưỡng những khoảnh khắc hạnh phúc."
-            </blockquote>
-            <br/>
-        </div>
-    const members = [
-        {
-            thumbnail: "/thumbnails/nhu-hien.jpg",
-            name: "TRẦN NHƯ HIỀN",
-            title: "PHÓ GIÁM ĐỐC"
-        },
-        {
-            thumbnail: "/thumbnails/thanh-my.jpg",
-            name: "KTS. ĐINH THANH MỸ",
-            title: "CHỦ TRÌ THIẾT KẾ"
-        },
-        {
-            thumbnail: "/thumbnails/thanh-tuan.jpg",
-            name: "KTS. LÂM THANH TUẤN",
-            title: "KIẾN TRÚC SƯ"
-        },
-        {
-            thumbnail: "/thumbnails/thuy-duong.jpg",
-            name: "KTS. LÊ THỊ THÙY DƯƠNG",
-            title: "KIẾN TRÚC SƯ"
-        },
-        {
-            thumbnail: "/thumbnails/hong-tham.jpg",
-            name: "PHẠM HỒNG THẮM",
-            title: "THIẾT KẾ NỘI THẤT"
-        },
-        {
-            thumbnail: "/thumbnails/van-thong.jpg",
-            name: "KS. NGUYỄN VĂN THỐNG",
-            title: "KỸ SƯ KẾT CẤU "
-        },
+    const [data, setData] = useState(null);
 
-    ]
+    useEffect(() => {
+        client.fetch(aboutPageQuery).then(setData);
+    }, []);
+
     useEffect(() => {
         // Set up animations after DOM is ready
         const swingObserver = animateOnObserve('.swing-in-top-fwd-2');
-        const borderObserver = animateOnObserve('.border-draw')
-        const puffObserver = animateOnObserve('.puff-in-center')
-        const slideObserver = animateOnObserve('.slide-in-bottom')
+        const borderObserver = animateOnObserve('.border-draw');
+        const puffObserver = animateOnObserve('.puff-in-center');
+        const slideObserver = animateOnObserve('.slide-in-bottom');
 
         // Cleanup function to disconnect observers
         return () => {
-            swingObserver.disconnect()
+            swingObserver.disconnect();
             puffObserver.disconnect();
-            borderObserver.disconnect()
+            borderObserver.disconnect();
             slideObserver.disconnect();
         };
     }, []);
 
     return (
         <div className="w-full bg-[#373737]">
-            {/* Hero section with background image */}
-            <section className="w-full bg-[#cb6d0d] py-30 overflow-x-clip">
-                <div className="mx-auto max-w-7xl px-6 md:px-12">
-                    <div className="flex gap-8">
-                        <h1 className="text-white text-xl font-bold [writing-mode:vertical-rl] text-nowrap shrink-0">
-                            VỀ CHÚNG TÔI
-                        </h1>
-
-                        <div className="grid min-w-0 grid-cols-1 lg:grid-cols-2 gap-12 border-l border-white pl-4">
-                            {/* Cột text */}
-                            <div className="relative min-w-0 px-10">
-                                <p className="text-white text-4xl">
-                                    CÔNG TY TNHH
-                                </p>
-                                <p className="text-white text-4xl whitespace-nowrap">
-                                    NHÀ ĐẸP QUẢNG NAM
-                                </p>
-                                <br/>
-                                <p className="text-white text-lg text-justify">Công ty TNHH NHÀ ĐẸP QUẢNG NAM do KTS Nguyên Tương
-                                    thành
-                                    lập. Với sự nhiệt huyết cùng đội
-                                    ngũ nhân sự trẻ trung và năng động, NĐQN mong muốn mang đến cho các bạn nhưng bản
-                                    thiết
-                                    kế đa dạng phong cách, mới lạ và tất nhiên sẽ phù hợp với từng đối tượng.
-                                </p>
-                                <br/>
-                                <p className="text-white text-lg text-justify">Với ước mơ tạo ra những ngôi nhà thật đẹp chàng kĩ
-                                    sư
-                                    trẻ
-                                    Nguyên Tương Tổng Giám Đốc tại công ty Nhà Đẹp Quảng Nam chia sẻ.
-                                    "Chúng tôi không chỉ đơn thuần xây dựng những công trình, mà còn kiến tạo nên những
-                                    tổ
-                                    ấm -
-                                    nơi gia đình sum vầy, nơi nuôi dưỡng những khoảnh khắc hạnh phúc."
-                                </p>
-                                <br/>
-                                <p className="text-white text-lg text-justify">Công ty TNHH NHÀ ĐẸP QUẢNG NAM do KTS Nguyên Tương
-                                    thành
-                                    lập. Với sự nhiệt huyết cùng đội
-                                    ngũ nhân sự trẻ trung và năng động, NĐQN mong muốn mang đến cho các bạn nhưng bản
-                                    thiết
-                                    kế đa dạng phong cách, mới lạ và tất nhiên sẽ phù hợp với từng đối tượng.
-                                </p>
-                                <br/>
-                                <p className="text-white text-lg text-justify">Với ước mơ tạo ra những ngôi nhà thật đẹp chàng kĩ
-                                    sư
-                                    trẻ
-                                    Nguyên Tương Tổng Giám Đốc tại công ty Nhà Đẹp Quảng Nam chia sẻ.
-                                    "Chúng tôi không chỉ đơn thuần xây dựng những công trình, mà còn kiến tạo nên những
-                                    tổ
-                                    ấm -
-                                    nơi gia đình sum vầy, nơi nuôi dưỡng những khoảnh khắc hạnh phúc."
-                                </p>
-                            </div>
-                            {/* Cột ảnh */}
-                            <Image
-                                src="/thumbnails/nguyen-tuong.jpg"
-                                alt="founder image"
-                                width={900}
-                                height={1600}
-                                className="w-full max-w-md lg:max-w-2xl object-cover aspect-[3/5]"
-                                priority
-                            />
-                        </div>
-                    </div>
-                </div>
-            </section>
-            <section className="py-12">
-                <div className="container max-w-6xl mx-auto px-4">
-                    <div className="text-center">
-                        {/*Title*/}
-                        <h2 className="text-white  text-3xl font-bold my-20  p-4 inline-block border-2 border-white">
-                            ĐỘI NGŨ
-                        </h2>
-                    </div>
-                    <div className="grid grid-cols-3 gap-4">
-                        <div className="text-center slide-in-bottom">
-                            <Image width={300} height={300} src="/thumbnails/nguyen-tuong.jpg"
-                                   alt="nguyen-tuong"
-                                   className="size-70 object-cover mx-auto mb-4"/>
-                            <h3 className="text-white font-bold text-xl mb-2">
-                                KTS. TRẦN NGUYÊN TƯƠNG
-                            </h3>
-                            <p className="text-white font-base text-sm">GIÁM ĐỐC</p>
-                        </div>
-                        <div className="col-span-2 slide-in-bottom">{aboutShort}</div>
-                        {members.map((member) => (
-                            <div className="text-center slide-in-bottom" key={member.name}>
-                                <Image width={300} height={300} src={member.thumbnail}
-                                       alt={member.name}
-                                       className="size-70 object-top object-cover mx-auto mb-4"/>
-                                <h3 className="text-white font-bold text-xl mb-2">
-                                    {member.name}
-                                </h3>
-                                <p className="text-white font-base text-sm">
-                                    {member.title}
-                                </p>
-                            </div>
-                        ))}
-                    </div>
-                </div>
-            </section>
+            <AboutHeroSection data={data?.heroSection} />
+            <TeamSection data={data?.teamSection} />
             <div>
                 {/*Office pictures*/}
                 <section className="pt-12">
@@ -268,3 +130,4 @@ export default function AboutPage() {
         </div>
     );
 }
+

--- a/src/app/(site)/contact/page.js
+++ b/src/app/(site)/contact/page.js
@@ -14,7 +14,6 @@ export default function Contact() {
         className="py-20 border-0"
       />
       <ContactForm />
-      <div className="bg-[#272727] pb-70"/>
     </div>
   );
 }

--- a/src/app/(site)/contact/page.js
+++ b/src/app/(site)/contact/page.js
@@ -3,7 +3,7 @@ import ContactForm from "@/components/ContactForm";
 
 export default function Contact() {
   return (
-    <div className="min-h-screen relative py-20 bg-[#272727]">
+    <div className="flex flex-col justify-end pt-30 bg-[#272727]">
       <iframe
         src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3843.066879055964!2d108.46746617655826!3d15.588075213549368!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x3169dd01ab243f49%3A0x4d0f0412ed7b3e37!2zMTc0IE5ndXnhu4VuIFbEg24gVHLhu5dpLCBQaMaw4budbmcgVMOibiBUaOG6oW5oLCBUYW0gS-G7sywgUXXhuqNuZyBOYW0sIFZpZXRuYW0!5e0!3m2!1sen!2s!4v1752638036873!5m2!1sen!2s"
         width="100%"
@@ -11,9 +11,8 @@ export default function Contact() {
         allowFullScreen=""
         loading="lazy"
         referrerPolicy="no-referrer-when-downgrade"
-        className="py-20 border-0"
+        className="border-0"
       />
-      <ContactForm />
     </div>
   );
 }

--- a/src/app/(site)/layout.js
+++ b/src/app/(site)/layout.js
@@ -1,22 +1,39 @@
-// src/app/(site)/layout.js
+'use client';
+import { usePathname } from 'next/navigation';
 import Navbar from "../../components/Navbar";
 import Footer from "../../components/Footer";
 import FloatingButtons from "../../components/FloatingButtons";
 import {client} from "@/sanity/lib/client";
 import {footerQuery} from "@/sanity/lib/queries";
 import ContactForm from "@/components/ContactForm";
+import { useEffect, useState } from 'react';
 
-export default async function SiteLayout({children}) {
-    const footerData = await client.fetch(footerQuery);
+export default function SiteLayout({children}) {
+    const pathname = usePathname();
+    const [footerData, setFooterData] = useState(null);
+
+    useEffect(() => {
+        const fetchFooterData = async () => {
+            const data = await client.fetch(footerQuery);
+            setFooterData(data);
+        };
+        fetchFooterData();
+    }, []);
+
+    // Check if current path is contact page
+    const isContactPage = pathname === '/contact' || pathname?.includes('/contact');
+
     return (
         <>
             <Navbar/>
             {children}
             <FloatingButtons/>
-            <div className="py-30">
-                <ContactForm/>
-            </div>
-            <div className="mt-30">
+            {!isContactPage && (
+                <div className="py-30">
+                    <ContactForm/>
+                </div>
+            )}
+            <div>
                 <Footer data={footerData}/>
             </div>
         </>

--- a/src/app/(site)/layout.js
+++ b/src/app/(site)/layout.js
@@ -1,12 +1,12 @@
 'use client';
-import { usePathname } from 'next/navigation';
+import {usePathname} from 'next/navigation';
 import Navbar from "../../components/Navbar";
 import Footer from "../../components/Footer";
 import FloatingButtons from "../../components/FloatingButtons";
 import {client} from "@/sanity/lib/client";
 import {footerQuery} from "@/sanity/lib/queries";
 import ContactForm from "@/components/ContactForm";
-import { useEffect, useState } from 'react';
+import {useEffect, useState} from 'react';
 
 export default function SiteLayout({children}) {
     const pathname = usePathname();
@@ -20,19 +20,14 @@ export default function SiteLayout({children}) {
         fetchFooterData();
     }, []);
 
-    // Check if current path is contact page
-    const isContactPage = pathname === '/contact' || pathname?.includes('/contact');
-
     return (
         <>
             <Navbar/>
             {children}
             <FloatingButtons/>
-            {!isContactPage && (
-                <div className="py-30">
-                    <ContactForm/>
-                </div>
-            )}
+            <div className="py-30">
+                <ContactForm/>
+            </div>
             <div>
                 <Footer data={footerData}/>
             </div>

--- a/src/app/(site)/page.js
+++ b/src/app/(site)/page.js
@@ -34,7 +34,7 @@ export default async function Home() {
                     </h3>
                 </div>
             </div>
-            <VisionSection/>
+            <VisionSection data={data?.visionSection}/>
             {/* Why Choose Us Section */
             }
             <section className="py-12 px-4 bg-white">

--- a/src/app/(site)/services/page.js
+++ b/src/app/(site)/services/page.js
@@ -176,7 +176,6 @@ const ServicesPage = () => {
           }
         }
       `}</style>
-      <ContactForm />
       <div className="h-70 bg-[#272727]"/>
     </div>
   );

--- a/src/app/(site)/services/page.js
+++ b/src/app/(site)/services/page.js
@@ -2,12 +2,12 @@
 
 import Banner from '@/components/ui/banner';
 import Image from 'next/image';
-import React, { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import ContactForm from '../../../components/ContactForm';
-import SectionHeading from "@/components/SectionHeading";
-import HeroCarousel from "@/components/HeroCarousel";
+import { client } from "@/sanity/lib/client";
+import { servicesPageQuery } from "@/sanity/lib/queries";
 
-const services = [
+const fallbackServices = [
   {
     id: 1,
     title: "Thiết kế thi công trọn gói",
@@ -51,8 +51,15 @@ const services = [
     alt: "Thi công nhà đã có bảng vẽ",
   },
 ];
-
 const ServicesPage = () => {
+  const [services, setServices] = useState([]);
+
+  useEffect(() => {
+    client.fetch(servicesPageQuery).then((data) => {
+      setServices(data?.services || []);
+    });
+  }, []);
+
   useEffect(() => {
     const sections = document.querySelectorAll('.service-section');
 
@@ -97,18 +104,20 @@ const ServicesPage = () => {
     return () => {
       sections.forEach((section) => observer.unobserve(section));
     };
-  }, []);
+  }, [services]);
+
+  const displayServices = services.length ? services : fallbackServices;
 
   return (
     <div className="min-h-screen bg-[#272727]">
       <Banner title="DỊCH VỤ" />
       <div className="container mx-auto px-6 md:px-10">
-        {services.map((service, index) => (
+        {displayServices.map((service, index) => (
           <div
-            key={service.id}
+            key={service.slug || service.id}
             className={`service-section flex flex-col md:flex-row min-h-[630px] justify-center w-full max-w-[1240px] mb-30 mx-auto px-20 gap-10 ${
               index % 2 === 0 ? 'md:flex-row' : 'md:flex-row-reverse'
-            } ${service.id % 2 === 1 ? 'odd' : 'even'}`}
+            } ${index % 2 === 0 ? 'odd' : 'even'}`}
           >
             <div className="w-full md:w-1/2 p-4 service-description flex flex-col justify-center">
               <h2 className="text-lg md:text-4xl md:whitespace-nowrap font-bold text-left text-orange-400 mb-6 ">
@@ -116,7 +125,7 @@ const ServicesPage = () => {
               </h2>
               <p className="text-white mb-4">{service.description}</p>
               <a
-                href={`/services/${service.id}`}
+                href={`/services/${service.slug || service.id}`}
                 className="w-fit inline-block px-4 py-2 border border-orange-400 bg-white text-orange-400 text-center hover:text-white hover:!bg-orange-400 font-semibold rounded-full duration-200 text-lg"
               >
                 Liên hệ
@@ -125,7 +134,7 @@ const ServicesPage = () => {
             <div className="w-full md:w-1/2 p-4 service-image relative">
               <Image
                 src={service.image}
-                alt={service.alt}
+                alt={service.alt || service.title}
                 fill
                 sizes="(max-width: 768px) 100vw, 50vw"
                 className="object-cover"

--- a/src/components/AboutHeroSection.js
+++ b/src/components/AboutHeroSection.js
@@ -9,14 +9,17 @@ export default function AboutHeroSection({ data }) {
                         {data?.title || 'VỀ CHÚNG TÔI'}
                     </h1>
 
-                    <div className="grid min-w-0 grid-cols-1 md:grid-cols-2 gap-12 border-l border-white pl-4">
+                    <div className="grid min-w-0 grid-cols-1 lg:grid-cols-2 gap-12 border-l border-white pl-4">
                         {/* Text Column */}
                         <div className="relative min-w-0 px-10">
-                            <h2 className="text-white text-5xl mb-8">
-                                {data?.companyName || 'CÔNG TY TNHH NHÀ ĐẸP QUẢNG NAM'}
-                            </h2>
+                            <p className="text-white md:text-2xl lg:text-4xl">
+                                CÔNG TY TNHH
+                            </p>
+                            <p className="text-white md:text-2xl text-4xl whitespace-nowrap">
+                                NHÀ ĐẸP QUẢNG NAM
+                            </p>
                             {data?.descriptions?.map((paragraph, index) => (
-                                <p key={index} className="text-white text-lg mb-4">
+                                <p key={index} className="text-white text-justify text-lg mb-4">
                                     {paragraph}
                                 </p>
                             ))}

--- a/src/components/AboutHeroSection.js
+++ b/src/components/AboutHeroSection.js
@@ -1,0 +1,39 @@
+import Image from "next/image";
+
+export default function AboutHeroSection({ data }) {
+    return (
+        <section className="w-full bg-orange-400 py-30 overflow-x-clip">
+            <div className="mx-auto max-w-7xl px-6 md:px-12">
+                <div className="flex gap-8">
+                    <h1 className="text-white text-xl font-bold [writing-mode:vertical-rl] text-nowrap shrink-0">
+                        {data?.title || 'VỀ CHÚNG TÔI'}
+                    </h1>
+
+                    <div className="grid min-w-0 grid-cols-1 md:grid-cols-2 gap-12 border-l border-white pl-4">
+                        {/* Text Column */}
+                        <div className="relative min-w-0 px-10">
+                            <h2 className="text-white text-5xl mb-8">
+                                {data?.companyName || 'CÔNG TY TNHH NHÀ ĐẸP QUẢNG NAM'}
+                            </h2>
+                            {data?.descriptions?.map((paragraph, index) => (
+                                <p key={index} className="text-white text-lg mb-4">
+                                    {paragraph}
+                                </p>
+                            ))}
+                        </div>
+                        {/* Image Column */}
+                        <Image
+                            src={data?.imageUrl || '/thumbnails/nguyen-tuong.jpg'}
+                            alt={data?.imageAlt || 'founder image'}
+                            width={900}
+                            height={1600}
+                            className="w-full max-w-md lg:max-w-2xl object-cover aspect-[3/5]"
+                            priority
+                        />
+                    </div>
+                </div>
+            </div>
+        </section>
+    );
+}
+

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -45,7 +45,7 @@ export default function Footer({data}) {
 
     return (
         <div>
-            <div className="bg-black h-32"/>
+            <div className="bg-transparent h-32"/>
             <div className="bg-black">
                 <footer className="relative overflow-visible">
                     {/* Decorative circle layers */}

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -44,75 +44,78 @@ export default function Footer({data}) {
     const circleSize = '400px';
 
     return (
-        <div className="bg-black">
-            <footer className="relative overflow-visible">
-                {/* Decorative circle layers */}
-                <div
-                    className="absolute ping border-8 border-orange-400 top-0 -translate-y-1/2 right-50 rounded-full pointer-events-none z-0 opacity-60 invisible lg:visible"
-                    style={{width: circleSize, height: circleSize}}
-                />
-                <div
-                    className="absolute top-0 border-8 border-orange-400 -translate-y-1/2 right-50 rounded-full z-0 opacity-60 invisible lg:visible"
-                    style={{width: circleSize, height: circleSize}}
-                />
-                <div
-                    className="absolute top-0 -translate-y-1/2 right-50 rounded-full z-20 invisible lg:visible overflow-visible"
-                    style={{width: circleSize, height: circleSize}}
-                >
-                    {/* CTA Circle Content */}
+        <div>
+            <div className="bg-black h-32"/>
+            <div className="bg-black">
+                <footer className="relative overflow-visible">
+                    {/* Decorative circle layers */}
                     <div
-                        className="absolute inset-6 bg-orange-400 rounded-full z-20 text-center flex flex-col items-center justify-center px-8 overflow-visible">
-                        <Image
-                            src={logo}
-                            alt="Logo"
-                            width={800}
-                            height={800}
-                            className="w-70 h-16 object-cover top-0"
-                        />
-                        <h2 className="text-white font-bold text-lg mb-6">{ctaText}</h2>
-                        <p className="text-gray-50 text-sm text-justify leading-relaxed mb-8">{description}</p>
-
-                        {/* ContactPopover with fixed positioning */}
-                        <div className="relative z-[9999]">
-                            <ContactPopover
-                                trigger={
-                                    <button
-                                        className="heartbeat bg-white text-black px-6 py-4 rounded-full font-semibold hover:bg-black hover:text-orange-400 transition-colors relative z-[9999]">
-                                        Liên hệ ngay
-                                    </button>
-                                }
+                        className="absolute ping border-8 border-orange-400 top-0 -translate-y-1/2 right-50 rounded-full pointer-events-none z-0 opacity-60 invisible lg:visible"
+                        style={{width: circleSize, height: circleSize}}
+                    />
+                    <div
+                        className="absolute top-0 border-8 border-orange-400 -translate-y-1/2 right-50 rounded-full z-0 opacity-60 invisible lg:visible"
+                        style={{width: circleSize, height: circleSize}}
+                    />
+                    <div
+                        className="absolute top-0 -translate-y-1/2 right-50 rounded-full z-20 invisible lg:visible overflow-visible"
+                        style={{width: circleSize, height: circleSize}}
+                    >
+                        {/* CTA Circle Content */}
+                        <div
+                            className="absolute inset-6 bg-orange-400 rounded-full z-20 text-center flex flex-col items-center justify-center px-8 overflow-visible">
+                            <Image
+                                src={logo}
+                                alt="Logo"
+                                width={800}
+                                height={800}
+                                className="w-70 h-16 object-cover top-0"
                             />
+                            <h2 className="text-white font-bold text-lg mb-6">{ctaText}</h2>
+                            <p className="text-gray-50 text-sm text-justify leading-relaxed mb-8">{description}</p>
+
+                            {/* ContactPopover with fixed positioning */}
+                            <div className="relative z-[9999]">
+                                <ContactPopover
+                                    trigger={
+                                        <button
+                                            className="heartbeat bg-white text-black px-6 py-4 rounded-full font-semibold hover:bg-black hover:text-orange-400 transition-colors relative z-[9999]">
+                                            Liên hệ ngay
+                                        </button>
+                                    }
+                                />
+                            </div>
                         </div>
                     </div>
-                </div>
 
-                {/* Main footer layout */}
-                <div className="relative z-10 w-full h-full flex bg-black text-white p-12">
-                    <div className="max-w-6xl text-left flex flex-col gap-8">
-                        {/* Column 1: Main Branch */}
-                        <div>
-                            <h3 className="text-2xl font-bold mb-3">{company}</h3>
-                            <div className="mb-2">{mainBranch.address}</div>
-                            {mainBranch.email && <div className="mb-2">Email: {mainBranch.email}</div>}
-                            {mainBranch.phones?.length > 0 && (
-                                <div className="mb-2">Số điện thoại: {mainBranch.phones.join(' - ')}</div>
-                            )}
-                        </div>
+                    {/* Main footer layout */}
+                    <div className="relative z-10 w-full h-full flex bg-black text-white p-12">
+                        <div className="max-w-6xl text-left flex flex-col gap-8">
+                            {/* Column 1: Main Branch */}
+                            <div>
+                                <h3 className="text-2xl font-bold mb-3">{company}</h3>
+                                <div className="mb-2">{mainBranch.address}</div>
+                                {mainBranch.email && <div className="mb-2">Email: {mainBranch.email}</div>}
+                                {mainBranch.phones?.length > 0 && (
+                                    <div className="mb-2">Số điện thoại: {mainBranch.phones.join(' - ')}</div>
+                                )}
+                            </div>
 
-                        {/* Columns 2 & 3: Other branches */}
-                        <div className="w-full">
-                            <p className="italic">
-                                Với ước mơ tạo ra những ngôi nhà thật đẹp chàng kĩ sư trẻ Nguyên Tương Tổng Giám Đốc tại
-                                công ty Nhà Đẹp Quảng Nam chia sẻ.
-                            </p>
-                            <p>
-                                "Chúng tôi không chỉ đơn thuần xây dựng những công trình, mà còn kiến tạo nên những tổ
-                                ấm - nơi gia đình sum vầy, nơi nuôi dưỡng những khoảnh khắc hạnh phúc."
-                            </p>
+                            {/* Columns 2 & 3: Other branches */}
+                            <div className="w-full">
+                                <p className="italic">
+                                    Với ước mơ tạo ra những ngôi nhà thật đẹp chàng kĩ sư trẻ Nguyên Tương Tổng Giám Đốc tại
+                                    công ty Nhà Đẹp Quảng Nam chia sẻ.
+                                </p>
+                                <p>
+                                    "Chúng tôi không chỉ đơn thuần xây dựng những công trình, mà còn kiến tạo nên những tổ
+                                    ấm - nơi gia đình sum vầy, nơi nuôi dưỡng những khoảnh khắc hạnh phúc."
+                                </p>
+                            </div>
                         </div>
                     </div>
-                </div>
-            </footer>
+                </footer>
+            </div>
         </div>
     );
 }

--- a/src/components/TeamSection.js
+++ b/src/components/TeamSection.js
@@ -1,0 +1,60 @@
+import Image from "next/image";
+
+export default function TeamSection({ data }) {
+    const ceo = data?.ceo;
+    const members = data?.members || [];
+    return (
+        <section className="py-12">
+            <div className="container max-w-6xl mx-auto px-4">
+                <div className="text-center">
+                    {/*Title*/}
+                    <h2 className="text-white  text-3xl font-bold my-20  p-4 inline-block border-2 border-white">
+                        ĐỘI NGŨ
+                    </h2>
+                </div>
+                <div className="grid grid-cols-3 gap-4">
+                    {ceo && (
+                        <div className="text-center slide-in-bottom">
+                            <Image
+                                width={300}
+                                height={300}
+                                src={ceo.thumbnailUrl || '/thumbnails/nguyen-tuong.jpg'}
+                                alt={ceo.name || 'nguyen-tuong'}
+                                className="size-70 object-cover mx-auto mb-4"
+                            />
+                            <h3 className="text-white font-bold text-xl mb-2">
+                                {ceo.name || 'KTS. TRẦN NGUYÊN TƯƠNG'}
+                            </h3>
+                            <p className="text-white font-base text-sm">
+                                {ceo.title || 'GIÁM ĐỐC'}
+                            </p>
+                        </div>
+                    )}
+                    <div className="col-span-2 slide-in-bottom">
+                        <p className="text-white text-lg">
+                            {data?.aboutShort || ''}
+                        </p>
+                    </div>
+                    {members.map((member) => (
+                        <div className="text-center slide-in-bottom" key={member.name}>
+                            <Image
+                                width={300}
+                                height={300}
+                                src={member.thumbnailUrl}
+                                alt={member.name}
+                                className="size-70 object-top object-cover mx-auto mb-4"
+                            />
+                            <h3 className="text-white font-bold text-xl mb-2">
+                                {member.name}
+                            </h3>
+                            <p className="text-white font-base text-sm">
+                                {member.title}
+                            </p>
+                        </div>
+                    ))}
+                </div>
+            </div>
+        </section>
+    );
+}
+

--- a/src/components/VisionSection.js
+++ b/src/components/VisionSection.js
@@ -1,58 +1,67 @@
 import * as React from "react";
 import Image from "next/image";
 
-export default function VisionSection() {
+export default function VisionSection({ data }) {
+    const fallback = {
+        vision: {
+            title: "Tầm nhìn",
+            description1: "Trở thành công ty xây dựng hàng đầu tại Việt Nam, được công nhận về sự xuất sắc trong thiết kế, thi công và quản lý dự án.",
+            description2: "Chúng tôi hướng tới việc tạo ra những công trình mang tính biểu tượng, đóng góp vào sự phát triển bền vững của đất nước.",
+            images: ["/images/TUYEN-DUNG.jpg", "/images/vision2.jpg"],
+        },
+        mission: {
+            title: "Sứ mệnh",
+            description1: "Xây dựng những công trình chất lượng cao, an toàn và thân thiện với môi trường, góp phần phát triển hạ tầng và nâng cao chất lượng cuộc sống cộng đồng",
+            description2: "Chúng tôi luôn đồng hành cùng đối tác để hiện thực hóa mọi dự án.",
+            images: ["/images/TUYEN-DUNG.jpg", "/images/vision2.jpg"],
+        },
+    };
+
+    const vision = data?.vision || fallback.vision;
+    const mission = data?.mission || fallback.mission;
+
+    const renderImages = (images, altPrefix) => (
+        <div className="flex-1 flex gap-4 overflow-hidden">
+            {images?.map((img, idx) => (
+                <Image
+                    key={idx}
+                    src={img.url || img}
+                    alt={`${altPrefix}-${idx + 1}`}
+                    width={300}
+                    height={400}
+                    className="object-cover aspect-[3/4] flex-1"
+                />
+            ))}
+        </div>
+    );
+
     return (
         <section className="py-16 px-4">
             {/* First Section - Text Left, Images Right */}
             <div className="max-w-6xl mx-auto flex items-center gap-8 mb-16">
                 {/* Left Side - Text Content */}
                 <div className="flex-1 text-right">
-                    <p className="text-orange-400 text-5xl font-bold mb-4">
-                        Tầm nhìn
-                    </p>
+                    <p className="text-orange-400 text-5xl font-bold mb-4">{vision.title}</p>
                     <div className="w-12 h-[2px] bg-gray-300 ml-auto my-4"/>
-                    <p className="mb-4">
-                        Trở thành công ty xây dựng hàng đầu tại Việt Nam, được công nhận về sự xuất sắc trong thiết kế,
-                        thi công và quản lý dự án.
-                    </p>
-                    <p>
-                        Chúng tôi hướng tới việc tạo ra những công trình mang tính biểu
-                        tượng, đóng góp vào sự phát triển bền vững của đất nước.
-                    </p>
+                    <p className="mb-4">{vision.description1}</p>
+                    <p>{vision.description2}</p>
                 </div>
 
                 {/* Right Side - Images */}
-                <div className="flex-1 flex gap-4 overflow-hidden">
-                    <Image src="/images/TUYEN-DUNG.jpg" alt="vision-1" width={300} height={400}
-                           className="object-cover aspect-[3/4] flex-1"/>
-                    <Image src="/images/vision2.jpg" alt="vision-2" width={300} height={400}
-                           className="object-cover aspect-[3/4] flex-1"/>
-                </div>
+                {renderImages(vision.images, 'vision')}
             </div>
 
             {/* Second Section - Images Left, Text Right */}
             <div className="max-w-6xl mx-auto flex items-center gap-8">
                 {/* Left Side - Images */}
-                <div className="flex-1 flex gap-4 overflow-hidden">
-                    <Image src="/images/TUYEN-DUNG.jpg" alt="mission-1" width={300} height={400}
-                           className="object-cover aspect-[3/4] flex-1"/>
-                    <Image src="/images/vision2.jpg" alt="mission-2" width={300} height={400}
-                           className="object-cover aspect-[3/4] flex-1"/>
-                </div>
+                {renderImages(mission.images, 'mission')}
 
                 {/* Right Side - Text Content */}
                 <div className="flex-1 text-left ml-auto">
-                    <p className="text-orange-400 text-5xl font-bold mb-4">
-                        Sứ mệnh
-                    </p>
+                    <p className="text-orange-400 text-5xl font-bold mb-4">{mission.title}</p>
                     <div className="w-12 h-[2px] bg-gray-300 my-4"/>
-                    <p className="mb-4">
-                        Xây dựng những công trình chất lượng cao, an toàn và thân thiện với môi trường, góp phần phát triển hạ tầng và nâng cao chất lượng cuộc sống cộng đồng
-                    </p>
-                    <p>
-                        Chúng tôi luôn đồng hành cùng đối tác để hiện thực hóa mọi dự án.
-                    </p>
+                    <p className="mb-4">{mission.description1}</p>
+                    <p>{mission.description2}</p>
                 </div>
             </div>
         </section>

--- a/src/sanity/lib/queries.js
+++ b/src/sanity/lib/queries.js
@@ -3,6 +3,20 @@ export const homepageQuery = `*[_type == "homepage"][0] {
   bannerTitle,
   sale,
   introduction,
+  visionSection{
+    vision{
+      title,
+      description1,
+      description2,
+      images[]{"url": asset->url}
+    },
+    mission{
+      title,
+      description1,
+      description2,
+      images[]{"url": asset->url}
+    }
+  },
   coreValues,
   whyChooseUs,
   processesTabs,
@@ -59,6 +73,16 @@ export const aboutPageQuery = `*[_type == "aboutPage"][0]{
   policies[]{
     title,
     icon
+  }
+}`
+
+export const servicesPageQuery = `*[_type == "servicesPage"][0]{
+  services[]{
+    title,
+    description,
+    alt,
+    "image": image.asset->url,
+    "slug": slug.current
   }
 }`
 

--- a/src/sanity/lib/queries.js
+++ b/src/sanity/lib/queries.js
@@ -46,12 +46,25 @@ export const footerQuery = `*[_type == "footerSettings"][0]{
 `;
 
 export const aboutPageQuery = `*[_type == "aboutPage"][0]{
-  aboutShort,
-  ceoQuote,
-  members[]{
-    name,
+  heroSection{
     title,
-    "thumbnailUrl": thumbnail.asset->url
+    companyName,
+    descriptions,
+    "imageUrl": image.asset->url,
+    imageAlt
+  },
+  teamSection{
+    aboutShort,
+    ceo{
+      name,
+      title,
+      "thumbnailUrl": thumbnail.asset->url
+    },
+    members[]{
+      name,
+      title,
+      "thumbnailUrl": thumbnail.asset->url
+    }
   },
   coreValues[]{
     title,

--- a/src/sanity/schemaTypes/aboutHeroSection.js
+++ b/src/sanity/schemaTypes/aboutHeroSection.js
@@ -1,0 +1,17 @@
+export default {
+    name: 'aboutHeroSection',
+    type: 'object',
+    title: 'Hero Section',
+    fields: [
+        {name: 'title', type: 'string', title: 'Tiêu đề'},
+        {name: 'companyName', type: 'string', title: 'Tên công ty'},
+        {
+            name: 'descriptions',
+            type: 'array',
+            title: 'Đoạn mô tả',
+            of: [{type: 'text'}]
+        },
+        {name: 'image', type: 'image', title: 'Ảnh'},
+        {name: 'imageAlt', type: 'string', title: 'Mô tả ảnh'}
+    ]
+};

--- a/src/sanity/schemaTypes/aboutPage.js
+++ b/src/sanity/schemaTypes/aboutPage.js
@@ -4,29 +4,14 @@ export default {
     title: 'Giới thiệu',
     fields: [
         {
-            name: 'aboutShort',
-            type: 'text',
-            title: 'Giới thiệu ngắn',
+            name: 'heroSection',
+            type: 'aboutHeroSection',
+            title: 'Hero Section'
         },
         {
-            name: 'ceoQuote',
-            type: 'text',
-            title: 'Trích dẫn CEO'
-        },
-        {
-            name: 'members',
-            type: 'array',
-            title: 'Thành viên đội ngũ',
-            of: [
-                {
-                    type: 'object',
-                    fields: [
-                        {name: 'name', type: 'string', title: 'Họ tên'},
-                        {name: 'title', type: 'string', title: 'Chức vụ'},
-                        {name: 'thumbnail', type: 'image', title: 'Ảnh đại diện'},
-                    ]
-                }
-            ]
+            name: 'teamSection',
+            type: 'teamSection',
+            title: 'Đội ngũ'
         },
         {
             name: 'coreValues',
@@ -104,8 +89,6 @@ export default {
         }
     },
     initialValue: {
-        aboutShort: 'Với ước mơ tạo ra những ngôi nhà thật đẹp chàng kĩ sư trẻ Nguyên Tương Tổng Giám Đốc tại công ty Nhà Đẹp Quảng Nam chia sẻ.',
-        ceoQuote: 'Chúng tôi không chỉ đơn thuần xây dựng những công trình, mà còn kiến tạo nên những tổ ấm - nơi gia đình sum vầy, nơi nuôi dưỡng những khoảnh khắc hạnh phúc.',
         commitments: [
             {
                 text: 'KHÔNG sử dụng vật tư kém chất lượng',

--- a/src/sanity/schemaTypes/homepage.js
+++ b/src/sanity/schemaTypes/homepage.js
@@ -43,6 +43,11 @@ export default {
             type: 'titleAndDescription'
         },
         {
+            name: 'visionSection',
+            title: 'Tầm nhìn và Sứ mệnh',
+            type: 'visionSection'
+        },
+        {
             name: 'coreValues',
             title: 'Giá trị cốt lõi',
             type: "array",

--- a/src/sanity/schemaTypes/index.js
+++ b/src/sanity/schemaTypes/index.js
@@ -12,6 +12,8 @@ import aboutPage from "@/sanity/schemaTypes/aboutPage";
 import visionSection from "@/sanity/schemaTypes/visionSection";
 import service from "@/sanity/schemaTypes/service";
 import servicesPage from "@/sanity/schemaTypes/servicesPage";
+import aboutHeroSection from "@/sanity/schemaTypes/aboutHeroSection";
+import teamSection from "@/sanity/schemaTypes/teamSection";
 
 export const schemas = {
     types: [
@@ -29,5 +31,7 @@ export const schemas = {
         visionSection,
         service,
         servicesPage,
+        aboutHeroSection,
+        teamSection,
     ],
 }

--- a/src/sanity/schemaTypes/index.js
+++ b/src/sanity/schemaTypes/index.js
@@ -9,7 +9,25 @@ import testimonial from "@/sanity/schemaTypes/testimonial";
 import contactSettings from "@/sanity/schemaTypes/contactSettings";
 import footerSettings from "@/sanity/schemaTypes/footerSettings";
 import aboutPage from "@/sanity/schemaTypes/aboutPage";
+import visionSection from "@/sanity/schemaTypes/visionSection";
+import service from "@/sanity/schemaTypes/service";
+import servicesPage from "@/sanity/schemaTypes/servicesPage";
 
 export const schemas = {
-    types: [homepage, youtubeEmbed, titleAndDescription, process, constructionVideo, project, partner, testimonial, contactSettings, footerSettings, aboutPage],
+    types: [
+        homepage,
+        youtubeEmbed,
+        titleAndDescription,
+        process,
+        constructionVideo,
+        project,
+        partner,
+        testimonial,
+        contactSettings,
+        footerSettings,
+        aboutPage,
+        visionSection,
+        service,
+        servicesPage,
+    ],
 }

--- a/src/sanity/schemaTypes/service.js
+++ b/src/sanity/schemaTypes/service.js
@@ -1,0 +1,12 @@
+export default {
+    name: 'service',
+    title: 'Dịch vụ',
+    type: 'object',
+    fields: [
+        { name: 'title', title: 'Tiêu đề', type: 'string', validation: Rule => Rule.required() },
+        { name: 'description', title: 'Mô tả', type: 'text', validation: Rule => Rule.required() },
+        { name: 'image', title: 'Hình ảnh', type: 'image', options: { hotspot: true }, validation: Rule => Rule.required() },
+        { name: 'alt', title: 'Alt text', type: 'string' },
+        { name: 'slug', title: 'Slug', type: 'slug', options: { source: 'title', maxLength: 96 } },
+    ],
+};

--- a/src/sanity/schemaTypes/servicesPage.js
+++ b/src/sanity/schemaTypes/servicesPage.js
@@ -1,0 +1,18 @@
+export default {
+    name: 'servicesPage',
+    title: 'Nội dung trang dịch vụ',
+    type: 'document',
+    fields: [
+        {
+            name: 'services',
+            title: 'Các dịch vụ',
+            type: 'array',
+            of: [{ type: 'service' }],
+        },
+    ],
+    preview: {
+        prepare() {
+            return { title: 'Trang dịch vụ' };
+        },
+    },
+};

--- a/src/sanity/schemaTypes/teamSection.js
+++ b/src/sanity/schemaTypes/teamSection.js
@@ -1,0 +1,33 @@
+export default {
+    name: 'teamSection',
+    type: 'object',
+    title: 'Đội ngũ',
+    fields: [
+        {
+            name: 'ceo',
+            type: 'object',
+            title: 'CEO',
+            fields: [
+                {name: 'name', type: 'string', title: 'Họ tên'},
+                {name: 'title', type: 'string', title: 'Chức vụ'},
+                {name: 'thumbnail', type: 'image', title: 'Ảnh đại diện'},
+            ]
+        },
+        {name: 'aboutShort', type: 'text', title: 'Giới thiệu ngắn'},
+        {
+            name: 'members',
+            type: 'array',
+            title: 'Thành viên đội ngũ',
+            of: [
+                {
+                    type: 'object',
+                    fields: [
+                        {name: 'name', type: 'string', title: 'Họ tên'},
+                        {name: 'title', type: 'string', title: 'Chức vụ'},
+                        {name: 'thumbnail', type: 'image', title: 'Ảnh đại diện'},
+                    ]
+                }
+            ]
+        }
+    ]
+};

--- a/src/sanity/schemaTypes/visionSection.js
+++ b/src/sanity/schemaTypes/visionSection.js
@@ -1,0 +1,41 @@
+export default {
+    name: 'visionSection',
+    title: 'Tầm nhìn và Sứ mệnh',
+    type: 'object',
+    fields: [
+        {
+            name: 'vision',
+            title: 'Tầm nhìn',
+            type: 'object',
+            fields: [
+                {name: 'title', title: 'Tiêu đề', type: 'string'},
+                {name: 'description1', title: 'Đoạn văn 1', type: 'text'},
+                {name: 'description2', title: 'Đoạn văn 2', type: 'text'},
+                {
+                    name: 'images',
+                    title: 'Hình ảnh',
+                    type: 'array',
+                    of: [{type: 'image', options: {hotspot: true}}],
+                    validation: (Rule) => Rule.max(2),
+                },
+            ],
+        },
+        {
+            name: 'mission',
+            title: 'Sứ mệnh',
+            type: 'object',
+            fields: [
+                {name: 'title', title: 'Tiêu đề', type: 'string'},
+                {name: 'description1', title: 'Đoạn văn 1', type: 'text'},
+                {name: 'description2', title: 'Đoạn văn 2', type: 'text'},
+                {
+                    name: 'images',
+                    title: 'Hình ảnh',
+                    type: 'array',
+                    of: [{type: 'image', options: {hotspot: true}}],
+                    validation: (Rule) => Rule.max(2),
+                },
+            ],
+        },
+    ],
+};


### PR DESCRIPTION
## Summary
- add Sanity schemas for vision section and services content
- refactor home and services pages to load these sections from Sanity
- update queries and schema index to register new types

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689eaf5141c483339fe97f1bd681a637