### PR TITLE
feat: add sanity schemas and refactor sections

### DIFF
--- a/src/app/(site)/about/page.js
+++ b/src/app/(site)/about/page.js
@@ -3,175 +3,40 @@ import Image from "next/image";
 import {useEffect, useState} from "react";
 import {CreditCard, Lock, ShieldUser} from "lucide-react";
 import animateOnObserve from "@/lib/animateOnObserve";
-import {fancyFont} from "@/app/fonts";
 import Commitments from "@/components/Commitments";
 import CoreValues from "@/components/CoreValues";
+import AboutHeroSection from "@/components/AboutHeroSection";
+import TeamSection from "@/components/TeamSection";
+import {client} from "@/sanity/lib/client";
+import {aboutPageQuery} from "@/sanity/lib/queries";
 
 export default function AboutPage() {
-    const [expanded, setExpanded] = useState(false);
-    const aboutShort =
-        <div className="text-white text-lg">
-            <p>
-                Với ước mơ tạo ra những ngôi nhà thật đẹp chàng kĩ sư trẻ Nguyên Tương Tổng Giám Đốc tại công ty Nhà Đẹp
-                Quảng Nam chia sẻ.
-            </p>
-            <br/>
-            <blockquote className="text-2xl italic mb-6 text-center md:text-left">
-                "Chúng tôi không chỉ đơn thuần xây dựng những công trình, mà còn kiến tạo nên những tổ ấm
-                - nơi gia đình sum vầy, nơi nuôi dưỡng những khoảnh khắc hạnh phúc."
-            </blockquote>
-            <br/>
-        </div>
-    const members = [
-        {
-            thumbnail: "/thumbnails/nhu-hien.jpg",
-            name: "TRẦN NHƯ HIỀN",
-            title: "PHÓ GIÁM ĐỐC"
-        },
-        {
-            thumbnail: "/thumbnails/thanh-my.jpg",
-            name: "KTS. ĐINH THANH MỸ",
-            title: "CHỦ TRÌ THIẾT KẾ"
-        },
-        {
-            thumbnail: "/thumbnails/thanh-tuan.jpg",
-            name: "KTS. LÂM THANH TUẤN",
-            title: "KIẾN TRÚC SƯ"
-        },
-        {
-            thumbnail: "/thumbnails/thuy-duong.jpg",
-            name: "KTS. LÊ THỊ THÙY DƯƠNG",
-            title: "KIẾN TRÚC SƯ"
-        },
-        {
-            thumbnail: "/thumbnails/hong-tham.jpg",
-            name: "PHẠM HỒNG THẮM",
-            title: "THIẾT KẾ NỘI THẤT"
-        },
-        {
-            thumbnail: "/thumbnails/van-thong.jpg",
-            name: "KS. NGUYỄN VĂN THỐNG",
-            title: "KỸ SƯ KẾT CẤU "
-        },
+    const [data, setData] = useState(null);
 
-    ]
+    useEffect(() => {
+        client.fetch(aboutPageQuery).then(setData);
+    }, []);
+
     useEffect(() => {
         // Set up animations after DOM is ready
         const swingObserver = animateOnObserve('.swing-in-top-fwd-2');
-        const borderObserver = animateOnObserve('.border-draw')
-        const puffObserver = animateOnObserve('.puff-in-center')
-        const slideObserver = animateOnObserve('.slide-in-bottom')
+        const borderObserver = animateOnObserve('.border-draw');
+        const puffObserver = animateOnObserve('.puff-in-center');
+        const slideObserver = animateOnObserve('.slide-in-bottom');
 
         // Cleanup function to disconnect observers
         return () => {
-            swingObserver.disconnect()
+            swingObserver.disconnect();
             puffObserver.disconnect();
-            borderObserver.disconnect()
+            borderObserver.disconnect();
             slideObserver.disconnect();
         };
     }, []);
 
     return (
         <div className="w-full bg-[#373737]">
-            {/* Hero section with background image */}
-            <section className="w-full bg-orange-400 py-30 overflow-x-clip">
-                <div className="mx-auto max-w-7xl px-6 md:px-12">
-                    <div className="flex gap-8">
-                        <h1 className="text-white text-xl font-bold [writing-mode:vertical-rl] text-nowrap shrink-0">
-                            VỀ CHÚNG TÔI
-                        </h1>
-
-                        <div className="grid min-w-0 grid-cols-1 md:grid-cols-2 gap-12 border-l border-white pl-4">
-                            {/* Cột text */}
-                            <div className="relative min-w-0 px-10">
-                                <h2 className="text-white text-5xl mb-8">
-                                    CÔNG TY TNHH NHÀ ĐẸP QUẢNG NAM
-                                </h2>
-                                <br/>
-                                <p className="text-white text-lg">Công ty TNHH NHÀ ĐẸP QUẢNG NAM do KTS Nguyên Tương
-                                    thành
-                                    lập. Với sự nhiệt huyết cùng đội
-                                    ngũ nhân sự trẻ trung và năng động, NĐQN mong muốn mang đến cho các bạn nhưng bản
-                                    thiết
-                                    kế đa dạng phong cách, mới lạ và tất nhiên sẽ phù hợp với từng đối tượng.
-                                </p>
-                                <br/>
-                                <p className="text-white text-lg">Với ước mơ tạo ra những ngôi nhà thật đẹp chàng kĩ
-                                    sư
-                                    trẻ
-                                    Nguyên Tương Tổng Giám Đốc tại công ty Nhà Đẹp Quảng Nam chia sẻ.
-                                    "Chúng tôi không chỉ đơn thuần xây dựng những công trình, mà còn kiến tạo nên những
-                                    tổ
-                                    ấm -
-                                    nơi gia đình sum vầy, nơi nuôi dưỡng những khoảnh khắc hạnh phúc."
-                                </p>
-                                <br/>
-                                <p className="text-white text-lg">Công ty TNHH NHÀ ĐẸP QUẢNG NAM do KTS Nguyên Tương
-                                    thành
-                                    lập. Với sự nhiệt huyết cùng đội
-                                    ngũ nhân sự trẻ trung và năng động, NĐQN mong muốn mang đến cho các bạn nhưng bản
-                                    thiết
-                                    kế đa dạng phong cách, mới lạ và tất nhiên sẽ phù hợp với từng đối tượng.
-                                </p>
-                                <br/>
-                                <p className="text-white text-lg">Với ước mơ tạo ra những ngôi nhà thật đẹp chàng kĩ
-                                    sư
-                                    trẻ
-                                    Nguyên Tương Tổng Giám Đốc tại công ty Nhà Đẹp Quảng Nam chia sẻ.
-                                    "Chúng tôi không chỉ đơn thuần xây dựng những công trình, mà còn kiến tạo nên những
-                                    tổ
-                                    ấm -
-                                    nơi gia đình sum vầy, nơi nuôi dưỡng những khoảnh khắc hạnh phúc."
-                                </p>
-                            </div>
-                            {/* Cột ảnh */}
-                            <Image
-                                src="/thumbnails/nguyen-tuong.jpg"
-                                alt="founder image"
-                                width={900}
-                                height={1600}
-                                className="w-full max-w-md lg:max-w-2xl object-cover aspect-[3/5]"
-                                priority
-                            />
-                        </div>
-                    </div>
-                </div>
-            </section>
-            <section className="py-12">
-                <div className="container max-w-6xl mx-auto px-4">
-                    <div className="text-center">
-                        {/*Title*/}
-                        <h2 className="text-white  text-3xl font-bold my-20  p-4 inline-block border-2 border-white">
-                            ĐỘI NGŨ
-                        </h2>
-                    </div>
-                    <div className="grid grid-cols-3 gap-4">
-                        <div className="text-center slide-in-bottom">
-                            <Image width={300} height={300} src="/thumbnails/nguyen-tuong.jpg"
-                                   alt="nguyen-tuong"
-                                   className="size-70 object-cover mx-auto mb-4"/>
-                            <h3 className="text-white font-bold text-xl mb-2">
-                                KTS. TRẦN NGUYÊN TƯƠNG
-                            </h3>
-                            <p className="text-white font-base text-sm">GIÁM ĐỐC</p>
-                        </div>
-                        <div className="col-span-2 slide-in-bottom">{aboutShort}</div>
-                        {members.map((member) => (
-                            <div className="text-center slide-in-bottom" key={member.name}>
-                                <Image width={300} height={300} src={member.thumbnail}
-                                       alt={member.name}
-                                       className="size-70 object-top object-cover mx-auto mb-4"/>
-                                <h3 className="text-white font-bold text-xl mb-2">
-                                    {member.name}
-                                </h3>
-                                <p className="text-white font-base text-sm">
-                                    {member.title}
-                                </p>
-                            </div>
-                        ))}
-                    </div>
-                </div>
-            </section>
+            <AboutHeroSection data={data?.heroSection} />
+            <TeamSection data={data?.teamSection} />
             <div>
                 {/*Office pictures*/}
                 <section className="pt-12">
@@ -265,3 +130,4 @@ export default function AboutPage() {
         </div>
     );
 }
+

--- a/src/app/(site)/page.js
+++ b/src/app/(site)/page.js
@@ -34,7 +34,7 @@ export default async function Home() {
                     </h3>
                 </div>
             </div>
-            <VisionSection/>
+            <VisionSection data={data?.visionSection}/>
             {/* Why Choose Us Section */
             }
             <section className="py-12 px-4 bg-white">

--- a/src/app/(site)/projects/[slug]/page.js
+++ b/src/app/(site)/projects/[slug]/page.js
@@ -1,0 +1,78 @@
+import Image from 'next/image';
+import { notFound } from 'next/navigation';
+import { client } from '@/sanity/lib/client';
+import { projectBySlugQuery, projectSlugsQuery } from '@/sanity/lib/queries';
+
+export async function generateStaticParams() {
+    const slugs = await client.fetch(projectSlugsQuery);
+    return slugs.map(({ slug }) => ({ slug }));
+}
+
+export default async function ProjectDetailPage({ params }) {
+    const { slug } = params;
+    const project = await client.fetch(projectBySlugQuery, { slug });
+
+    if (!project) {
+        notFound();
+    }
+
+    const { title, information, gallery, description, sections } = project;
+
+    return (
+        <div className="min-h-screen bg-[#272727] text-white">
+            <div className="container mx-auto py-10 px-6">
+                <h1 className="text-3xl font-bold mb-6">{title}</h1>
+                {information && (
+                    <div className="space-y-1 mb-8">
+                        {information.shortDescription && <p>{information.shortDescription}</p>}
+                        {information.location && <p>Địa điểm: {information.location}</p>}
+                        {information.floors && <p>Số tầng: {information.floors}</p>}
+                        {information.landArea && <p>Diện tích đất: {information.landArea}</p>}
+                        {information.constructionArea && <p>Diện tích xây dựng: {information.constructionArea}</p>}
+                        {information.cost && <p>Chi phí: {information.cost}</p>}
+                    </div>
+                )}
+                {gallery && gallery.length > 0 && (
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-8">
+                        {gallery.map((img, idx) => (
+                            <Image
+                                key={idx}
+                                src={img.url}
+                                alt={img.alt || title}
+                                width={800}
+                                height={600}
+                                className="w-full h-auto"
+                            />
+                        ))}
+                    </div>
+                )}
+                {description && <p className="mb-8 whitespace-pre-line">{description}</p>}
+                {sections && sections.length > 0 && (
+                    <div className="space-y-12">
+                        {sections.map((section, idx) => (
+                            <div key={idx}>
+                                {section.image && (
+                                    <div className="mb-4">
+                                        <Image
+                                            src={section.image.url}
+                                            alt={section.image.alt || title}
+                                            width={800}
+                                            height={600}
+                                            className="w-full h-auto"
+                                        />
+                                        {section.imageSubtitle && (
+                                            <p className="text-sm italic mt-2">{section.imageSubtitle}</p>
+                                        )}
+                                    </div>
+                                )}
+                                {section.content && (
+                                    <p className="whitespace-pre-line">{section.content}</p>
+                                )}
+                            </div>
+                        ))}
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/src/app/(site)/services/page.js
+++ b/src/app/(site)/services/page.js
@@ -2,12 +2,12 @@
 
 import Banner from '@/components/ui/banner';
 import Image from 'next/image';
-import React, { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import ContactForm from '../../../components/ContactForm';
-import SectionHeading from "@/components/SectionHeading";
-import HeroCarousel from "@/components/HeroCarousel";
+import { client } from "@/sanity/lib/client";
+import { servicesPageQuery } from "@/sanity/lib/queries";
 
-const services = [
+const fallbackServices = [
   {
     id: 1,
     title: "Thiết kế thi công trọn gói",
@@ -51,8 +51,15 @@ const services = [
     alt: "Thi công nhà đã có bảng vẽ",
   },
 ];
-
 const ServicesPage = () => {
+  const [services, setServices] = useState([]);
+
+  useEffect(() => {
+    client.fetch(servicesPageQuery).then((data) => {
+      setServices(data?.services || []);
+    });
+  }, []);
+
   useEffect(() => {
     const sections = document.querySelectorAll('.service-section');
 
@@ -97,18 +104,20 @@ const ServicesPage = () => {
     return () => {
       sections.forEach((section) => observer.unobserve(section));
     };
-  }, []);
+  }, [services]);
+
+  const displayServices = services.length ? services : fallbackServices;
 
   return (
     <div className="min-h-screen bg-[#272727]">
       <Banner title="DỊCH VỤ" />
       <div className="container mx-auto px-6 md:px-10">
-        {services.map((service, index) => (
+        {displayServices.map((service, index) => (
           <div
-            key={service.id}
+            key={service.slug || service.id}
             className={`service-section flex flex-col md:flex-row min-h-[630px] justify-center w-full max-w-[1240px] mb-30 mx-auto px-20 gap-10 ${
               index % 2 === 0 ? 'md:flex-row' : 'md:flex-row-reverse'
-            } ${service.id % 2 === 1 ? 'odd' : 'even'}`}
+            } ${index % 2 === 0 ? 'odd' : 'even'}`}
           >
             <div className="w-full md:w-1/2 p-4 service-description flex flex-col justify-center">
               <h2 className="text-lg md:text-4xl md:whitespace-nowrap font-bold text-left text-orange-400 mb-6 ">
@@ -116,7 +125,7 @@ const ServicesPage = () => {
               </h2>
               <p className="text-white mb-4">{service.description}</p>
               <a
-                href={`/services/${service.id}`}
+                href={`/services/${service.slug || service.id}`}
                 className="w-fit inline-block px-4 py-2 border border-orange-400 bg-white text-orange-400 text-center hover:text-white hover:!bg-orange-400 font-semibold rounded-full duration-200 text-lg"
               >
                 Liên hệ
@@ -125,7 +134,7 @@ const ServicesPage = () => {
             <div className="w-full md:w-1/2 p-4 service-image relative">
               <Image
                 src={service.image}
-                alt={service.alt}
+                alt={service.alt || service.title}
                 fill
                 sizes="(max-width: 768px) 100vw, 50vw"
                 className="object-cover"

--- a/src/components/AboutHeroSection.js
+++ b/src/components/AboutHeroSection.js
@@ -1,0 +1,39 @@
+import Image from "next/image";
+
+export default function AboutHeroSection({ data }) {
+    return (
+        <section className="w-full bg-orange-400 py-30 overflow-x-clip">
+            <div className="mx-auto max-w-7xl px-6 md:px-12">
+                <div className="flex gap-8">
+                    <h1 className="text-white text-xl font-bold [writing-mode:vertical-rl] text-nowrap shrink-0">
+                        {data?.title || 'VỀ CHÚNG TÔI'}
+                    </h1>
+
+                    <div className="grid min-w-0 grid-cols-1 md:grid-cols-2 gap-12 border-l border-white pl-4">
+                        {/* Text Column */}
+                        <div className="relative min-w-0 px-10">
+                            <h2 className="text-white text-5xl mb-8">
+                                {data?.companyName || 'CÔNG TY TNHH NHÀ ĐẸP QUẢNG NAM'}
+                            </h2>
+                            {data?.descriptions?.map((paragraph, index) => (
+                                <p key={index} className="text-white text-lg mb-4">
+                                    {paragraph}
+                                </p>
+                            ))}
+                        </div>
+                        {/* Image Column */}
+                        <Image
+                            src={data?.imageUrl || '/thumbnails/nguyen-tuong.jpg'}
+                            alt={data?.imageAlt || 'founder image'}
+                            width={900}
+                            height={1600}
+                            className="w-full max-w-md lg:max-w-2xl object-cover aspect-[3/5]"
+                            priority
+                        />
+                    </div>
+                </div>
+            </div>
+        </section>
+    );
+}
+

--- a/src/components/TeamSection.js
+++ b/src/components/TeamSection.js
@@ -1,0 +1,60 @@
+import Image from "next/image";
+
+export default function TeamSection({ data }) {
+    const ceo = data?.ceo;
+    const members = data?.members || [];
+    return (
+        <section className="py-12">
+            <div className="container max-w-6xl mx-auto px-4">
+                <div className="text-center">
+                    {/*Title*/}
+                    <h2 className="text-white  text-3xl font-bold my-20  p-4 inline-block border-2 border-white">
+                        ĐỘI NGŨ
+                    </h2>
+                </div>
+                <div className="grid grid-cols-3 gap-4">
+                    {ceo && (
+                        <div className="text-center slide-in-bottom">
+                            <Image
+                                width={300}
+                                height={300}
+                                src={ceo.thumbnailUrl || '/thumbnails/nguyen-tuong.jpg'}
+                                alt={ceo.name || 'nguyen-tuong'}
+                                className="size-70 object-cover mx-auto mb-4"
+                            />
+                            <h3 className="text-white font-bold text-xl mb-2">
+                                {ceo.name || 'KTS. TRẦN NGUYÊN TƯƠNG'}
+                            </h3>
+                            <p className="text-white font-base text-sm">
+                                {ceo.title || 'GIÁM ĐỐC'}
+                            </p>
+                        </div>
+                    )}
+                    <div className="col-span-2 slide-in-bottom">
+                        <p className="text-white text-lg">
+                            {data?.aboutShort || ''}
+                        </p>
+                    </div>
+                    {members.map((member) => (
+                        <div className="text-center slide-in-bottom" key={member.name}>
+                            <Image
+                                width={300}
+                                height={300}
+                                src={member.thumbnailUrl}
+                                alt={member.name}
+                                className="size-70 object-top object-cover mx-auto mb-4"
+                            />
+                            <h3 className="text-white font-bold text-xl mb-2">
+                                {member.name}
+                            </h3>
+                            <p className="text-white font-base text-sm">
+                                {member.title}
+                            </p>
+                        </div>
+                    ))}
+                </div>
+            </div>
+        </section>
+    );
+}
+

--- a/src/components/VisionSection.js
+++ b/src/components/VisionSection.js
@@ -1,58 +1,67 @@
 import * as React from "react";
 import Image from "next/image";
 
-export default function VisionSection() {
+export default function VisionSection({ data }) {
+    const fallback = {
+        vision: {
+            title: "Tầm nhìn",
+            description1: "Trở thành công ty xây dựng hàng đầu tại Việt Nam, được công nhận về sự xuất sắc trong thiết kế, thi công và quản lý dự án.",
+            description2: "Chúng tôi hướng tới việc tạo ra những công trình mang tính biểu tượng, đóng góp vào sự phát triển bền vững của đất nước.",
+            images: ["/images/TUYEN-DUNG.jpg", "/images/vision2.jpg"],
+        },
+        mission: {
+            title: "Sứ mệnh",
+            description1: "Xây dựng những công trình chất lượng cao, an toàn và thân thiện với môi trường, góp phần phát triển hạ tầng và nâng cao chất lượng cuộc sống cộng đồng",
+            description2: "Chúng tôi luôn đồng hành cùng đối tác để hiện thực hóa mọi dự án.",
+            images: ["/images/TUYEN-DUNG.jpg", "/images/vision2.jpg"],
+        },
+    };
+
+    const vision = data?.vision || fallback.vision;
+    const mission = data?.mission || fallback.mission;
+
+    const renderImages = (images, altPrefix) => (
+        <div className="flex-1 flex gap-4 overflow-hidden">
+            {images?.map((img, idx) => (
+                <Image
+                    key={idx}
+                    src={img.url || img}
+                    alt={`${altPrefix}-${idx + 1}`}
+                    width={300}
+                    height={400}
+                    className="object-cover aspect-[3/4] flex-1"
+                />
+            ))}
+        </div>
+    );
+
     return (
         <section className="py-16 px-4">
             {/* First Section - Text Left, Images Right */}
             <div className="max-w-6xl mx-auto flex items-center gap-8 mb-16">
                 {/* Left Side - Text Content */}
                 <div className="flex-1 text-right">
-                    <p className="text-orange-400 text-5xl font-bold mb-4">
-                        Tầm nhìn
-                    </p>
+                    <p className="text-orange-400 text-5xl font-bold mb-4">{vision.title}</p>
                     <div className="w-12 h-[2px] bg-gray-300 ml-auto my-4"/>
-                    <p className="mb-4">
-                        Trở thành công ty xây dựng hàng đầu tại Việt Nam, được công nhận về sự xuất sắc trong thiết kế,
-                        thi công và quản lý dự án.
-                    </p>
-                    <p>
-                        Chúng tôi hướng tới việc tạo ra những công trình mang tính biểu
-                        tượng, đóng góp vào sự phát triển bền vững của đất nước.
-                    </p>
+                    <p className="mb-4">{vision.description1}</p>
+                    <p>{vision.description2}</p>
                 </div>
 
                 {/* Right Side - Images */}
-                <div className="flex-1 flex gap-4 overflow-hidden">
-                    <Image src="/images/TUYEN-DUNG.jpg" alt="vision-1" width={300} height={400}
-                           className="object-cover aspect-[3/4] flex-1"/>
-                    <Image src="/images/vision2.jpg" alt="vision-2" width={300} height={400}
-                           className="object-cover aspect-[3/4] flex-1"/>
-                </div>
+                {renderImages(vision.images, 'vision')}
             </div>
 
             {/* Second Section - Images Left, Text Right */}
             <div className="max-w-6xl mx-auto flex items-center gap-8">
                 {/* Left Side - Images */}
-                <div className="flex-1 flex gap-4 overflow-hidden">
-                    <Image src="/images/TUYEN-DUNG.jpg" alt="mission-1" width={300} height={400}
-                           className="object-cover aspect-[3/4] flex-1"/>
-                    <Image src="/images/vision2.jpg" alt="mission-2" width={300} height={400}
-                           className="object-cover aspect-[3/4] flex-1"/>
-                </div>
+                {renderImages(mission.images, 'mission')}
 
                 {/* Right Side - Text Content */}
                 <div className="flex-1 text-left ml-auto">
-                    <p className="text-orange-400 text-5xl font-bold mb-4">
-                        Sứ mệnh
-                    </p>
+                    <p className="text-orange-400 text-5xl font-bold mb-4">{mission.title}</p>
                     <div className="w-12 h-[2px] bg-gray-300 my-4"/>
-                    <p className="mb-4">
-                        Xây dựng những công trình chất lượng cao, an toàn và thân thiện với môi trường, góp phần phát triển hạ tầng và nâng cao chất lượng cuộc sống cộng đồng
-                    </p>
-                    <p>
-                        Chúng tôi luôn đồng hành cùng đối tác để hiện thực hóa mọi dự án.
-                    </p>
+                    <p className="mb-4">{mission.description1}</p>
+                    <p>{mission.description2}</p>
                 </div>
             </div>
         </section>

--- a/src/sanity/lib/queries.js
+++ b/src/sanity/lib/queries.js
@@ -3,6 +3,20 @@ export const homepageQuery = `*[_type == "homepage"][0] {
   bannerTitle,
   sale,
   introduction,
+  visionSection{
+    vision{
+      title,
+      description1,
+      description2,
+      images[]{"url": asset->url}
+    },
+    mission{
+      title,
+      description1,
+      description2,
+      images[]{"url": asset->url}
+    }
+  },
   coreValues,
   whyChooseUs,
   processesTabs,
@@ -32,12 +46,25 @@ export const footerQuery = `*[_type == "footerSettings"][0]{
 `;
 
 export const aboutPageQuery = `*[_type == "aboutPage"][0]{
-  aboutShort,
-  ceoQuote,
-  members[]{
-    name,
+  heroSection{
     title,
-    "thumbnailUrl": thumbnail.asset->url
+    companyName,
+    descriptions,
+    "imageUrl": image.asset->url,
+    imageAlt
+  },
+  teamSection{
+    aboutShort,
+    ceo{
+      name,
+      title,
+      "thumbnailUrl": thumbnail.asset->url
+    },
+    members[]{
+      name,
+      title,
+      "thumbnailUrl": thumbnail.asset->url
+    }
   },
   coreValues[]{
     title,
@@ -61,4 +88,37 @@ export const aboutPageQuery = `*[_type == "aboutPage"][0]{
     icon
   }
 }`
+
+export const servicesPageQuery = `*[_type == "servicesPage"][0]{
+  services[]{
+    title,
+    description,
+    alt,
+    "image": image.asset->url,
+    "slug": slug.current
+  }
+}`
+
+export const projectSlugsQuery = `*[_type == "projectDetail" && defined(slug.current)]{
+  "slug": slug.current
+}`;
+
+export const projectBySlugQuery = `*[_type == "projectDetail" && slug.current == $slug][0]{
+  title,
+  information,
+  "slug": slug.current,
+  gallery[]{
+    "url": asset->url,
+    alt
+  },
+  description,
+  sections[]{
+    content,
+    image{
+      "url": asset->url,
+      alt
+    },
+    imageSubtitle
+  }
+}`;
 

--- a/src/sanity/schemaTypes/aboutHeroSection.js
+++ b/src/sanity/schemaTypes/aboutHeroSection.js
@@ -1,0 +1,17 @@
+export default {
+    name: 'aboutHeroSection',
+    type: 'object',
+    title: 'Hero Section',
+    fields: [
+        {name: 'title', type: 'string', title: 'Tiêu đề'},
+        {name: 'companyName', type: 'string', title: 'Tên công ty'},
+        {
+            name: 'descriptions',
+            type: 'array',
+            title: 'Đoạn mô tả',
+            of: [{type: 'text'}]
+        },
+        {name: 'image', type: 'image', title: 'Ảnh'},
+        {name: 'imageAlt', type: 'string', title: 'Mô tả ảnh'}
+    ]
+};

--- a/src/sanity/schemaTypes/aboutPage.js
+++ b/src/sanity/schemaTypes/aboutPage.js
@@ -4,29 +4,14 @@ export default {
     title: 'Giới thiệu',
     fields: [
         {
-            name: 'aboutShort',
-            type: 'text',
-            title: 'Giới thiệu ngắn',
+            name: 'heroSection',
+            type: 'aboutHeroSection',
+            title: 'Hero Section'
         },
         {
-            name: 'ceoQuote',
-            type: 'text',
-            title: 'Trích dẫn CEO'
-        },
-        {
-            name: 'members',
-            type: 'array',
-            title: 'Thành viên đội ngũ',
-            of: [
-                {
-                    type: 'object',
-                    fields: [
-                        {name: 'name', type: 'string', title: 'Họ tên'},
-                        {name: 'title', type: 'string', title: 'Chức vụ'},
-                        {name: 'thumbnail', type: 'image', title: 'Ảnh đại diện'},
-                    ]
-                }
-            ]
+            name: 'teamSection',
+            type: 'teamSection',
+            title: 'Đội ngũ'
         },
         {
             name: 'coreValues',
@@ -104,8 +89,6 @@ export default {
         }
     },
     initialValue: {
-        aboutShort: 'Với ước mơ tạo ra những ngôi nhà thật đẹp chàng kĩ sư trẻ Nguyên Tương Tổng Giám Đốc tại công ty Nhà Đẹp Quảng Nam chia sẻ.',
-        ceoQuote: 'Chúng tôi không chỉ đơn thuần xây dựng những công trình, mà còn kiến tạo nên những tổ ấm - nơi gia đình sum vầy, nơi nuôi dưỡng những khoảnh khắc hạnh phúc.',
         commitments: [
             {
                 text: 'KHÔNG sử dụng vật tư kém chất lượng',

--- a/src/sanity/schemaTypes/homepage.js
+++ b/src/sanity/schemaTypes/homepage.js
@@ -43,6 +43,11 @@ export default {
             type: 'titleAndDescription'
         },
         {
+            name: 'visionSection',
+            title: 'Tầm nhìn và Sứ mệnh',
+            type: 'visionSection'
+        },
+        {
             name: 'coreValues',
             title: 'Giá trị cốt lõi',
             type: "array",

--- a/src/sanity/schemaTypes/index.js
+++ b/src/sanity/schemaTypes/index.js
@@ -9,7 +9,31 @@ import testimonial from "@/sanity/schemaTypes/testimonial";
 import contactSettings from "@/sanity/schemaTypes/contactSettings";
 import footerSettings from "@/sanity/schemaTypes/footerSettings";
 import aboutPage from "@/sanity/schemaTypes/aboutPage";
+import visionSection from "@/sanity/schemaTypes/visionSection";
+import service from "@/sanity/schemaTypes/service";
+import servicesPage from "@/sanity/schemaTypes/servicesPage";
+import aboutHeroSection from "@/sanity/schemaTypes/aboutHeroSection";
+import teamSection from "@/sanity/schemaTypes/teamSection";
+import projectDetail from "@/sanity/schemaTypes/projectDetail";
 
 export const schemas = {
-    types: [homepage, youtubeEmbed, titleAndDescription, process, constructionVideo, project, partner, testimonial, contactSettings, footerSettings, aboutPage],
+    types: [
+        homepage,
+        youtubeEmbed,
+        titleAndDescription,
+        process,
+        constructionVideo,
+        project,
+        partner,
+        testimonial,
+        contactSettings,
+        footerSettings,
+        aboutPage,
+        visionSection,
+        service,
+        servicesPage,
+        aboutHeroSection,
+        teamSection,
+        projectDetail,
+    ],
 }

--- a/src/sanity/schemaTypes/projectDetail.js
+++ b/src/sanity/schemaTypes/projectDetail.js
@@ -1,0 +1,88 @@
+export default {
+    name: 'projectDetail',
+    title: 'Dự án',
+    type: 'document',
+    fields: [
+        {
+            name: 'title',
+            title: 'Tiêu đề',
+            type: 'string',
+            validation: Rule => Rule.required()
+        },
+        {
+            name: 'information',
+            title: 'Thông tin',
+            type: 'object',
+            fields: [
+                { name: 'shortDescription', title: 'Mô tả ngắn', type: 'string' },
+                { name: 'location', title: 'Địa điểm', type: 'string' },
+                { name: 'floors', title: 'Số tầng', type: 'string' },
+                { name: 'landArea', title: 'Diện tích đất', type: 'string' },
+                { name: 'constructionArea', title: 'Diện tích xây dựng', type: 'string' },
+                { name: 'cost', title: 'Chi phí', type: 'string' },
+            ]
+        },
+        {
+            name: 'slug',
+            title: 'Slug',
+            type: 'slug',
+            options: {
+                source: 'title',
+                maxLength: 96
+            },
+            validation: Rule => Rule.required()
+        },
+        {
+            name: 'gallery',
+            title: 'Thư viện ảnh',
+            type: 'array',
+            of: [
+                {
+                    type: 'image',
+                    options: { hotspot: true },
+                    fields: [
+                        {
+                            name: 'alt',
+                            title: 'Alt',
+                            type: 'string',
+                            description: 'Tự động tạo từ tiêu đề nếu bỏ trống'
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            name: 'description',
+            title: 'Mô tả',
+            type: 'text'
+        },
+        {
+            name: 'sections',
+            title: 'Các phần',
+            type: 'array',
+            of: [
+                {
+                    type: 'object',
+                    fields: [
+                        { name: 'content', title: 'Nội dung', type: 'text' },
+                        {
+                            name: 'image',
+                            title: 'Hình ảnh',
+                            type: 'image',
+                            options: { hotspot: true },
+                            fields: [
+                                {
+                                    name: 'alt',
+                                    title: 'Alt',
+                                    type: 'string',
+                                    description: 'Tự động tạo từ tiêu đề nếu bỏ trống'
+                                }
+                            ]
+                        },
+                        { name: 'imageSubtitle', title: 'Chú thích ảnh', type: 'string' }
+                    ]
+                }
+            ]
+        }
+    ]
+};

--- a/src/sanity/schemaTypes/service.js
+++ b/src/sanity/schemaTypes/service.js
@@ -1,0 +1,12 @@
+export default {
+    name: 'service',
+    title: 'Dịch vụ',
+    type: 'object',
+    fields: [
+        { name: 'title', title: 'Tiêu đề', type: 'string', validation: Rule => Rule.required() },
+        { name: 'description', title: 'Mô tả', type: 'text', validation: Rule => Rule.required() },
+        { name: 'image', title: 'Hình ảnh', type: 'image', options: { hotspot: true }, validation: Rule => Rule.required() },
+        { name: 'alt', title: 'Alt text', type: 'string' },
+        { name: 'slug', title: 'Slug', type: 'slug', options: { source: 'title', maxLength: 96 } },
+    ],
+};

--- a/src/sanity/schemaTypes/servicesPage.js
+++ b/src/sanity/schemaTypes/servicesPage.js
@@ -1,0 +1,18 @@
+export default {
+    name: 'servicesPage',
+    title: 'Nội dung trang dịch vụ',
+    type: 'document',
+    fields: [
+        {
+            name: 'services',
+            title: 'Các dịch vụ',
+            type: 'array',
+            of: [{ type: 'service' }],
+        },
+    ],
+    preview: {
+        prepare() {
+            return { title: 'Trang dịch vụ' };
+        },
+    },
+};

--- a/src/sanity/schemaTypes/teamSection.js
+++ b/src/sanity/schemaTypes/teamSection.js
@@ -1,0 +1,33 @@
+export default {
+    name: 'teamSection',
+    type: 'object',
+    title: 'Đội ngũ',
+    fields: [
+        {
+            name: 'ceo',
+            type: 'object',
+            title: 'CEO',
+            fields: [
+                {name: 'name', type: 'string', title: 'Họ tên'},
+                {name: 'title', type: 'string', title: 'Chức vụ'},
+                {name: 'thumbnail', type: 'image', title: 'Ảnh đại diện'},
+            ]
+        },
+        {name: 'aboutShort', type: 'text', title: 'Giới thiệu ngắn'},
+        {
+            name: 'members',
+            type: 'array',
+            title: 'Thành viên đội ngũ',
+            of: [
+                {
+                    type: 'object',
+                    fields: [
+                        {name: 'name', type: 'string', title: 'Họ tên'},
+                        {name: 'title', type: 'string', title: 'Chức vụ'},
+                        {name: 'thumbnail', type: 'image', title: 'Ảnh đại diện'},
+                    ]
+                }
+            ]
+        }
+    ]
+};

--- a/src/sanity/schemaTypes/visionSection.js
+++ b/src/sanity/schemaTypes/visionSection.js
@@ -1,0 +1,41 @@
+export default {
+    name: 'visionSection',
+    title: 'Tầm nhìn và Sứ mệnh',
+    type: 'object',
+    fields: [
+        {
+            name: 'vision',
+            title: 'Tầm nhìn',
+            type: 'object',
+            fields: [
+                {name: 'title', title: 'Tiêu đề', type: 'string'},
+                {name: 'description1', title: 'Đoạn văn 1', type: 'text'},
+                {name: 'description2', title: 'Đoạn văn 2', type: 'text'},
+                {
+                    name: 'images',
+                    title: 'Hình ảnh',
+                    type: 'array',
+                    of: [{type: 'image', options: {hotspot: true}}],
+                    validation: (Rule) => Rule.max(2),
+                },
+            ],
+        },
+        {
+            name: 'mission',
+            title: 'Sứ mệnh',
+            type: 'object',
+            fields: [
+                {name: 'title', title: 'Tiêu đề', type: 'string'},
+                {name: 'description1', title: 'Đoạn văn 1', type: 'text'},
+                {name: 'description2', title: 'Đoạn văn 2', type: 'text'},
+                {
+                    name: 'images',
+                    title: 'Hình ảnh',
+                    type: 'array',
+                    of: [{type: 'image', options: {hotspot: true}}],
+                    validation: (Rule) => Rule.max(2),
+                },
+            ],
+        },
+    ],
+};


### PR DESCRIPTION
## Summary
- refactor about page hero and team sections into standalone components
- add Sanity schemas for hero and team sections and update about page schema and query
- add project detail schema and dynamic page for individual projects

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689eaf5141c483339fe97f1bd681a637