### PR TITLE
refactor page components to server side

### DIFF
--- a/src/app/(site)/about/page.js
+++ b/src/app/(site)/about/page.js
@@ -1,42 +1,21 @@
-"use client";
 import Image from "next/image";
-import {useEffect, useState} from "react";
 import {CreditCard, Lock, ShieldUser} from "lucide-react";
-import animateOnObserve from "@/lib/animateOnObserve";
 import Commitments from "@/components/Commitments";
 import CoreValues from "@/components/CoreValues";
 import AboutHeroSection from "@/components/AboutHeroSection";
 import TeamSection from "@/components/TeamSection";
+import AboutPageAnimations from "@/components/AboutPageAnimations";
 import {client} from "@/sanity/lib/client";
 import {aboutPageQuery} from "@/sanity/lib/queries";
 
-export default function AboutPage() {
-    const [data, setData] = useState(null);
-
-    useEffect(() => {
-        client.fetch(aboutPageQuery).then(setData);
-    }, []);
-
-    useEffect(() => {
-        // Set up animations after DOM is ready
-        const swingObserver = animateOnObserve('.swing-in-top-fwd-2');
-        const borderObserver = animateOnObserve('.border-draw');
-        const puffObserver = animateOnObserve('.puff-in-center');
-        const slideObserver = animateOnObserve('.slide-in-bottom');
-
-        // Cleanup function to disconnect observers
-        return () => {
-            swingObserver.disconnect();
-            puffObserver.disconnect();
-            borderObserver.disconnect();
-            slideObserver.disconnect();
-        };
-    }, []);
+export default async function AboutPage() {
+    const data = await client.fetch(aboutPageQuery);
 
     return (
         <div className="w-full bg-[#373737]">
-            <AboutHeroSection data={data?.heroSection} />
-            <TeamSection data={data?.teamSection} />
+            <AboutPageAnimations/>
+            <AboutHeroSection data={data?.heroSection}/>
+            <TeamSection data={data?.teamSection}/>
             <div>
                 {/*Office pictures*/}
                 <section className="pt-12">

--- a/src/app/(site)/completed-projects/page.js
+++ b/src/app/(site)/completed-projects/page.js
@@ -1,10 +1,6 @@
-"use client";
-
 import Projects from "@/components/Projects";
 
 export default function CompletedProject() {
-
-  return (
-    <Projects pageTitle="Thi công thực tế"/>
-  );
+  return <Projects pageTitle="Thi công thực tế"/>;
 }
+

--- a/src/app/(site)/projects/page.js
+++ b/src/app/(site)/projects/page.js
@@ -1,17 +1,6 @@
-"use client";
-
-import React, {useEffect, useState} from 'react';
-import Image from 'next/image';
-import {Search} from 'lucide-react';
-import Link from 'next/link';
-import ContactForm from '../../../components/ContactForm';
-import Banner from '@/components/ui/banner';
-import SectionHeading from "@/components/SectionHeading";
-import {useSearchParams} from "next/navigation";
 import Projects from "@/components/Projects";
 
-export default function ProjectsPage(effect, deps) {
-    return (
-        <Projects pageTitle="Dự án"/>
-    );
+export default function ProjectsPage() {
+    return <Projects pageTitle="Dự án"/>;
 }
+

--- a/src/app/(site)/services/page.js
+++ b/src/app/(site)/services/page.js
@@ -1,11 +1,7 @@
-"use client";
-
 import Banner from '@/components/ui/banner';
-import Image from 'next/image';
-import { useEffect, useState } from 'react';
-import ContactForm from '../../../components/ContactForm';
-import { client } from "@/sanity/lib/client";
-import { servicesPageQuery } from "@/sanity/lib/queries";
+import ServiceSections from '@/components/ServiceSections';
+import { client } from '@/sanity/lib/client';
+import { servicesPageQuery } from '@/sanity/lib/queries';
 
 const fallbackServices = [
   {
@@ -51,134 +47,19 @@ const fallbackServices = [
     alt: "Thi công nhà đã có bảng vẽ",
   },
 ];
-const ServicesPage = () => {
-  const [services, setServices] = useState([]);
 
-  useEffect(() => {
-    client.fetch(servicesPageQuery).then((data) => {
-      setServices(data?.services || []);
-    });
-  }, []);
-
-  useEffect(() => {
-    const sections = document.querySelectorAll('.service-section');
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((entry) => {
-          if (entry.isIntersecting && window.innerWidth >= 768) {
-            const images = entry.target.querySelectorAll('img');
-            let loadedCount = 0;
-            const totalImages = images.length;
-
-            if (totalImages === 0) {
-              entry.target.classList.add('animate');
-              return;
-            }
-
-            images.forEach((img) => {
-              if (img.complete) {
-                loadedCount++;
-                if (loadedCount === totalImages) {
-                  entry.target.classList.add('animate');
-                }
-              } else {
-                img.addEventListener('load', () => {
-                  loadedCount++;
-                  if (loadedCount === totalImages) {
-                    entry.target.classList.add('animate');
-                  }
-                });
-              }
-            });
-          } else {
-            entry.target.classList.remove('animate');
-          }
-        });
-      },
-      { threshold: 0.2 }
-    );
-
-    sections.forEach((section) => observer.observe(section));
-
-    return () => {
-      sections.forEach((section) => observer.unobserve(section));
-    };
-  }, [services]);
-
-  const displayServices = services.length ? services : fallbackServices;
+export default async function ServicesPage() {
+  const data = await client.fetch(servicesPageQuery);
+  const services = data?.services && data.services.length > 0 ? data.services : fallbackServices;
 
   return (
     <div className="min-h-screen bg-[#272727]">
       <Banner title="DỊCH VỤ" />
       <div className="container mx-auto px-6 md:px-10">
-        {displayServices.map((service, index) => (
-          <div
-            key={service.slug || service.id}
-            className={`service-section flex flex-col md:flex-row min-h-[630px] justify-center w-full max-w-[1240px] mb-30 mx-auto px-20 gap-10 ${
-              index % 2 === 0 ? 'md:flex-row' : 'md:flex-row-reverse'
-            } ${index % 2 === 0 ? 'odd' : 'even'}`}
-          >
-            <div className="w-full md:w-1/2 p-4 service-description flex flex-col justify-center">
-              <h2 className="text-lg md:text-4xl md:whitespace-nowrap font-bold text-left text-orange-400 mb-6 ">
-                {service.title}
-              </h2>
-              <p className="text-white mb-4">{service.description}</p>
-              <a
-                href={`/services/${service.slug || service.id}`}
-                className="w-fit inline-block px-4 py-2 border border-orange-400 bg-white text-orange-400 text-center hover:text-white hover:!bg-orange-400 font-semibold rounded-full duration-200 text-lg"
-              >
-                Liên hệ
-              </a>
-            </div>
-            <div className="w-full md:w-1/2 p-4 service-image relative">
-              <Image
-                src={service.image}
-                alt={service.alt || service.title}
-                fill
-                sizes="(max-width: 768px) 100vw, 50vw"
-                className="object-cover"
-                priority={index === 0}
-              />
-            </div>
-          </div>
-        ))}
+        <ServiceSections services={services} />
       </div>
-      <style jsx>{`
-        .service-description,
-        .service-image {
-          opacity: 1;
-          transform: translateX(0);
-          transition: opacity 0.6s ease-out, transform 0.6s ease-out;
-        }
-
-        @media (min-width: 768px) {
-          .odd .service-description,
-          .even .service-image {
-            opacity: 0;
-            transform: translateX(-100px);
-          }
-          .odd .service-image,
-          .even .service-description {
-            opacity: 0;
-            transform: translateX(100px);
-          }
-
-          .animate.odd .service-description,
-          .animate.even .service-image {
-            opacity: 1;
-            transform: translateX(0);
-          }
-          .animate.odd .service-image,
-          .animate.even .service-description {
-            opacity: 1;
-            transform: translateX(0);
-          }
-        }
-      `}</style>
-      <div className="h-70 bg-[#272727]"/>
+      <div className="h-70 bg-[#272727]" />
     </div>
   );
-};
+}
 
-export default ServicesPage;

--- a/src/components/AboutPageAnimations.js
+++ b/src/components/AboutPageAnimations.js
@@ -1,0 +1,23 @@
+'use client';
+
+import {useEffect} from 'react';
+import animateOnObserve from '@/lib/animateOnObserve';
+
+export default function AboutPageAnimations() {
+    useEffect(() => {
+        const swingObserver = animateOnObserve('.swing-in-top-fwd-2');
+        const borderObserver = animateOnObserve('.border-draw');
+        const puffObserver = animateOnObserve('.puff-in-center');
+        const slideObserver = animateOnObserve('.slide-in-bottom');
+
+        return () => {
+            swingObserver.disconnect();
+            borderObserver.disconnect();
+            puffObserver.disconnect();
+            slideObserver.disconnect();
+        };
+    }, []);
+
+    return null;
+}
+

--- a/src/components/ServiceSections.js
+++ b/src/components/ServiceSections.js
@@ -1,0 +1,119 @@
+'use client';
+
+import Image from 'next/image';
+import {useEffect} from 'react';
+
+export default function ServiceSections({services}) {
+    useEffect(() => {
+        const sections = document.querySelectorAll('.service-section');
+
+        const observer = new IntersectionObserver(
+            (entries) => {
+                entries.forEach((entry) => {
+                    if (entry.isIntersecting && window.innerWidth >= 768) {
+                        const images = entry.target.querySelectorAll('img');
+                        let loadedCount = 0;
+                        const totalImages = images.length;
+
+                        if (totalImages === 0) {
+                            entry.target.classList.add('animate');
+                            return;
+                        }
+
+                        images.forEach((img) => {
+                            if (img.complete) {
+                                loadedCount++;
+                                if (loadedCount === totalImages) {
+                                    entry.target.classList.add('animate');
+                                }
+                            } else {
+                                img.addEventListener('load', () => {
+                                    loadedCount++;
+                                    if (loadedCount === totalImages) {
+                                        entry.target.classList.add('animate');
+                                    }
+                                });
+                            }
+                        });
+                    } else {
+                        entry.target.classList.remove('animate');
+                    }
+                });
+            },
+            {threshold: 0.2}
+        );
+
+        sections.forEach((section) => observer.observe(section));
+
+        return () => {
+            sections.forEach((section) => observer.unobserve(section));
+        };
+    }, [services]);
+
+    return (
+        <>
+            {services.map((service, index) => (
+                <div
+                    key={service.slug || service.id}
+                    className={`service-section flex flex-col md:flex-row min-h-[630px] justify-center w-full max-w-[1240px] mb-30 mx-auto px-20 gap-10 ${index % 2 === 0 ? 'md:flex-row odd' : 'md:flex-row-reverse even'}`}
+                >
+                    <div className="w-full md:w-1/2 p-4 service-description flex flex-col justify-center">
+                        <h2 className="text-lg md:text-4xl md:whitespace-nowrap font-bold text-left text-orange-400 mb-6">
+                            {service.title}
+                        </h2>
+                        <p className="text-white mb-4">{service.description}</p>
+                        <a
+                            href={`/services/${service.slug || service.id}`}
+                            className="w-fit inline-block px-4 py-2 border border-orange-400 bg-white text-orange-400 text-center hover:text-white hover:!bg-orange-400 font-semibold rounded-full duration-200 text-lg"
+                        >
+                            Liên hệ
+                        </a>
+                    </div>
+                    <div className="w-full md:w-1/2 p-4 service-image relative">
+                        <Image
+                            src={service.image}
+                            alt={service.alt || service.title}
+                            fill
+                            sizes="(max-width: 768px) 100vw, 50vw"
+                            className="object-cover"
+                            priority={index === 0}
+                        />
+                    </div>
+                </div>
+            ))}
+            <style jsx>{`
+        .service-description,
+        .service-image {
+          opacity: 1;
+          transform: translateX(0);
+          transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+        }
+
+        @media (min-width: 768px) {
+          .odd .service-description,
+          .even .service-image {
+            opacity: 0;
+            transform: translateX(-100px);
+          }
+          .odd .service-image,
+          .even .service-description {
+            opacity: 0;
+            transform: translateX(100px);
+          }
+
+          .animate.odd .service-description,
+          .animate.even .service-image {
+            opacity: 1;
+            transform: translateX(0);
+          }
+          .animate.odd .service-image,
+          .animate.even .service-description {
+            opacity: 1;
+            transform: translateX(0);
+          }
+        }
+      `}</style>
+        </>
+    );
+}
+

--- a/src/components/ui/banner.js
+++ b/src/components/ui/banner.js
@@ -1,3 +1,5 @@
+"use client";
+
 import { debounce } from "lodash";
 import { useCallback, useEffect, useRef, useState } from "react";
 import Image from 'next/image';


### PR DESCRIPTION
## Summary
- refactor About page to fetch data on the server and delegate animation hooks to a new `AboutPageAnimations` component
- refactor Services page to server component and render animated sections through a new `ServiceSections` client component
- clean project listing pages and mark banner as a client component

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f098c94c48333b84c622e7ba20274