### PR TITLE
Add project detail enhancements and Sanity-backed listings

### DIFF
--- a/src/app/(site)/completed-projects/page.js
+++ b/src/app/(site)/completed-projects/page.js
@@ -1,10 +1,10 @@
 import {client} from "@/sanity/lib/client";
-import {projectsQuery} from "@/sanity/lib/queries";
+import {completedProjectsQuery} from "@/sanity/lib/queries";
 import Banner from "@/components/ui/banner";
 import ProjectsGrid from "@/components/ProjectsGrid";
 
 export default async function CompletedProject() {
-  const projects = await client.fetch(projectsQuery, { isCompleted: true });
+  const projects = await client.fetch(completedProjectsQuery);
   return (
     <div className="min-h-screen bg-[#272727] text-white">
       <Banner title="Thi công thực tế" />

--- a/src/app/(site)/completed-projects/page.js
+++ b/src/app/(site)/completed-projects/page.js
@@ -1,6 +1,18 @@
-import Projects from "@/components/Projects";
+import {client} from "@/sanity/lib/client";
+import {projectsQuery} from "@/sanity/lib/queries";
+import Banner from "@/components/ui/banner";
+import ProjectsGrid from "@/components/ProjectsGrid";
 
-export default function CompletedProject() {
-  return <Projects pageTitle="Thi công thực tế"/>;
+export default async function CompletedProject() {
+  const projects = await client.fetch(projectsQuery, { isCompleted: true });
+  return (
+    <div className="min-h-screen bg-[#272727] text-white">
+      <Banner title="Thi công thực tế" />
+      <div className="py-20 px-6 md:px-10 container mx-auto">
+        <ProjectsGrid projects={projects} />
+      </div>
+      <div className="pb-70 bg-[#272727]"/>
+    </div>
+  );
 }
 

--- a/src/app/(site)/projects/[slug]/page.js
+++ b/src/app/(site)/projects/[slug]/page.js
@@ -22,6 +22,13 @@ export default async function ProjectDetailPage({ params }) {
     const siteSettings = await client.fetch(siteSettingsQuery);
 
     const { title, information, gallery, description, sections, category, _createdAt } = project;
+    const categoryLabels = {
+        mansion: 'Biệt thự',
+        urbanHouse: 'Nhà phố',
+        countryHouse: 'Nhà vườn',
+        neoClassicHouse: 'Nhà tân cổ điển',
+        serviceBuilding: 'Công trình dịch vụ',
+    };
 
     return (
         <div className="min-h-screen bg-[#272727] text-white">
@@ -33,7 +40,7 @@ export default async function ProjectDetailPage({ params }) {
                     {category && (
                         <>
                             <span className="mx-1">&gt;</span>
-                            <span>{category}</span>
+                            <span>{categoryLabels[category] || category}</span>
                         </>
                     )}
                     <span className="mx-1">&gt;</span>

--- a/src/app/(site)/projects/[slug]/page.js
+++ b/src/app/(site)/projects/[slug]/page.js
@@ -1,7 +1,11 @@
 import Image from 'next/image';
+import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { client } from '@/sanity/lib/client';
-import { projectBySlugQuery, projectSlugsQuery } from '@/sanity/lib/queries';
+import { projectBySlugQuery, projectSlugsQuery, contactFormQuery, siteSettingsQuery } from '@/sanity/lib/queries';
+import ContactForm from '@/components/ContactForm';
+import ProjectGallery from '@/components/ProjectGallery';
+import { Facebook, Youtube } from 'lucide-react';
 
 export async function generateStaticParams() {
     const slugs = await client.fetch(projectSlugsQuery);
@@ -11,67 +15,99 @@ export async function generateStaticParams() {
 export default async function ProjectDetailPage({ params }) {
     const { slug } = params;
     const project = await client.fetch(projectBySlugQuery, { slug });
-
     if (!project) {
         notFound();
     }
+    const contactData = await client.fetch(contactFormQuery);
+    const siteSettings = await client.fetch(siteSettingsQuery);
 
-    const { title, information, gallery, description, sections } = project;
+    const { title, information, gallery, description, sections, category, _createdAt } = project;
 
     return (
         <div className="min-h-screen bg-[#272727] text-white">
             <div className="container mx-auto py-10 px-6">
-                <h1 className="text-3xl font-bold mb-6">{title}</h1>
-                {information && (
-                    <div className="space-y-1 mb-8">
-                        {information.shortDescription && <p>{information.shortDescription}</p>}
-                        {information.location && <p>Địa điểm: {information.location}</p>}
-                        {information.floors && <p>Số tầng: {information.floors}</p>}
-                        {information.landArea && <p>Diện tích đất: {information.landArea}</p>}
-                        {information.constructionArea && <p>Diện tích xây dựng: {information.constructionArea}</p>}
-                        {information.cost && <p>Chi phí: {information.cost}</p>}
-                    </div>
-                )}
-                {gallery && gallery.length > 0 && (
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-8">
-                        {gallery.map((img, idx) => (
-                            <Image
-                                key={idx}
-                                src={img.url}
-                                alt={img.alt || title}
-                                width={800}
-                                height={600}
-                                className="w-full h-auto"
-                            />
-                        ))}
-                    </div>
-                )}
-                {description && <p className="mb-8 whitespace-pre-line">{description}</p>}
-                {sections && sections.length > 0 && (
-                    <div className="space-y-12">
-                        {sections.map((section, idx) => (
-                            <div key={idx}>
-                                {section.image && (
-                                    <div className="mb-4">
-                                        <Image
-                                            src={section.image.url}
-                                            alt={section.image.alt || title}
-                                            width={800}
-                                            height={600}
-                                            className="w-full h-auto"
-                                        />
-                                        {section.imageSubtitle && (
-                                            <p className="text-sm italic mt-2">{section.imageSubtitle}</p>
+                <nav className="text-sm text-gray-400 mb-4">
+                    <Link href="/" className="hover:underline">Trang chủ</Link>
+                    <span className="mx-1">&gt;</span>
+                    <Link href="/projects" className="hover:underline">Dự án</Link>
+                    {category && (
+                        <>
+                            <span className="mx-1">&gt;</span>
+                            <span>{category}</span>
+                        </>
+                    )}
+                    <span className="mx-1">&gt;</span>
+                    <span className="text-white">{title}</span>
+                </nav>
+                <div className="grid md:grid-cols-3 gap-8">
+                    <div className="md:col-span-2">
+                        <h1 className="text-3xl font-bold mb-2">{title}</h1>
+                        <div className="flex items-center gap-4 mb-6">
+                            {siteSettings?.facebook && (
+                                <a href={siteSettings.facebook} target="_blank" rel="noopener noreferrer" aria-label="Facebook">
+                                    <Facebook className="w-5 h-5" />
+                                </a>
+                            )}
+                            {siteSettings?.zalo && (
+                                <a href={siteSettings.zalo} target="_blank" rel="noopener noreferrer" aria-label="Zalo">
+                                    <Image src="/images/Icon_of_Zalo.svg" alt="Zalo" width={20} height={20} />
+                                </a>
+                            )}
+                            {siteSettings?.youtube && (
+                                <a href={siteSettings.youtube} target="_blank" rel="noopener noreferrer" aria-label="YouTube">
+                                    <Youtube className="w-5 h-5" />
+                                </a>
+                            )}
+                            <span className="text-sm text-gray-400">{new Date(_createdAt).toLocaleDateString('vi-VN')}</span>
+                        </div>
+                        {information && (
+                            <div className="space-y-1 mb-8">
+                                {information.shortDescription && <p>{information.shortDescription}</p>}
+                                {information.location && <p>Địa điểm: {information.location}</p>}
+                                {information.floors && <p>Số tầng: {information.floors}</p>}
+                                {information.landArea && <p>Diện tích đất: {information.landArea}</p>}
+                                {information.constructionArea && <p>Diện tích xây dựng: {information.constructionArea}</p>}
+                                {information.cost && <p>Chi phí: {information.cost}</p>}
+                            </div>
+                        )}
+                        {gallery && gallery.length > 0 && (
+                            <div className="mb-8">
+                                <ProjectGallery images={gallery} />
+                            </div>
+                        )}
+                        {description && <p className="mb-8 whitespace-pre-line">{description}</p>}
+                        {sections && sections.length > 0 && (
+                            <div className="space-y-12">
+                                {sections.map((section, idx) => (
+                                    <div key={idx}>
+                                        {section.image && (
+                                            <div className="mb-4">
+                                                <Image
+                                                    src={section.image.url}
+                                                    alt={section.image.alt || title}
+                                                    width={800}
+                                                    height={600}
+                                                    className="w-full h-auto"
+                                                />
+                                                {section.imageSubtitle && (
+                                                    <p className="text-sm italic mt-2">{section.imageSubtitle}</p>
+                                                )}
+                                            </div>
+                                        )}
+                                        {section.content && (
+                                            <p className="whitespace-pre-line">{section.content}</p>
                                         )}
                                     </div>
-                                )}
-                                {section.content && (
-                                    <p className="whitespace-pre-line">{section.content}</p>
-                                )}
+                                ))}
                             </div>
-                        ))}
+                        )}
                     </div>
-                )}
+                    <div className="md:col-span-1">
+                        <div className="sticky top-4">
+                            <ContactForm data={contactData} compact />
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
     );

--- a/src/app/(site)/projects/page.js
+++ b/src/app/(site)/projects/page.js
@@ -4,7 +4,7 @@ import Banner from "@/components/ui/banner";
 import ProjectsGrid from "@/components/ProjectsGrid";
 
 export default async function ProjectsPage() {
-    const projects = await client.fetch(projectsQuery, { isCompleted: false });
+    const projects = await client.fetch(projectsQuery);
     return (
         <div className="min-h-screen bg-[#272727] text-white">
             <Banner title="Dự án" />

--- a/src/app/(site)/projects/page.js
+++ b/src/app/(site)/projects/page.js
@@ -1,6 +1,18 @@
-import Projects from "@/components/Projects";
+import {client} from "@/sanity/lib/client";
+import {projectsQuery} from "@/sanity/lib/queries";
+import Banner from "@/components/ui/banner";
+import ProjectsGrid from "@/components/ProjectsGrid";
 
-export default function ProjectsPage() {
-    return <Projects pageTitle="Dự án"/>;
+export default async function ProjectsPage() {
+    const projects = await client.fetch(projectsQuery, { isCompleted: false });
+    return (
+        <div className="min-h-screen bg-[#272727] text-white">
+            <Banner title="Dự án" />
+            <div className="py-20 px-6 md:px-10 container mx-auto">
+                <ProjectsGrid projects={projects} />
+            </div>
+            <div className="pb-70 bg-[#272727]"/>
+        </div>
+    );
 }
 

--- a/src/components/ContactForm.js
+++ b/src/components/ContactForm.js
@@ -22,7 +22,7 @@ const fallback = {
     budgetOptions: ['1 tỷ - 1.5 tỷ', '1.6 tỷ - 2 tỷ', '2 tỷ - 2.5 tỷ', '3 tỷ trở lên'],
 };
 
-export default function ContactForm({ data, isPopover = false }) {
+export default function ContactForm({ data, isPopover = false, compact = false }) {
     // Use Sanity data with per-field fallbacks
     const title = data?.title || fallback.title;
     const subtitle = data?.subtitle || fallback.subtitle;
@@ -48,22 +48,23 @@ export default function ContactForm({ data, isPopover = false }) {
 
     return (
         <div className={`
-            max-w-6xl mx-auto 
-            grid grid-cols-1 ${isPopover ? 'lg:grid-cols-2' : 'md:grid-cols-2'} 
-            gap-6 md:gap-12 
-            items-start 
+            max-w-6xl mx-auto
+            grid grid-cols-1 ${isPopover ? 'lg:grid-cols-2' : 'md:grid-cols-2'}
+            gap-6 md:gap-12
+            items-start
             ${!isPopover ? 'rounded-xl shadow-lg bg-white p-8' : ''}
+            ${compact ? 'p-4 gap-4 md:gap-6' : ''}
         `}>
             {/* Contact Info */}
             <div>
-                <h2 className="text-lg md:text-xl mb-2 flex items-center gap-2 font-bold text-orange-400">
+                <h2 className={`text-lg md:text-xl flex items-center gap-2 font-bold text-orange-400 ${compact ? 'mb-1' : 'mb-2'}` }>
                     {title}
                     <span className="flex-1 h-0.5 bg-orange-300 ml-2" />
                 </h2>
-                <h3 className="text-sm md:text-md italic text-left mb-6 md:mb-8">{subtitle}</h3>
+                <h3 className={`text-sm md:text-md italic text-left ${compact ? 'mb-3 md:mb-4' : 'mb-6 md:mb-8'}`}>{subtitle}</h3>
 
-                <h4 className="text-base md:text-lg font-semibold text-gray-900 mb-4">MỌI THẮC MẮC XIN LIÊN HỆ:</h4>
-                <ul className="space-y-4 md:space-y-6">
+                <h4 className={`text-base md:text-lg font-semibold text-gray-900 ${compact ? 'mb-2' : 'mb-4'}`}>MỌI THẮC MẮC XIN LIÊN HỆ:</h4>
+                <ul className={`${compact ? 'space-y-2 md:space-y-3' : 'space-y-4 md:space-y-6'}`}>
                     <li className="flex items-start gap-3 md:gap-4">
                         <span className="w-10 h-10 md:w-12 md:h-12 flex items-center justify-center rounded-full bg-orange-300 text-white mt-1 flex-shrink-0">
                             <MapPin className="w-4 h-4 md:w-5 md:h-5" />
@@ -102,12 +103,12 @@ export default function ContactForm({ data, isPopover = false }) {
             </div>
 
             {/* Contact Form */}
-            <form className="space-y-4 md:space-y-6 contact" id="contact">
+            <form className={`${compact ? 'space-y-2 md:space-y-3' : 'space-y-4 md:space-y-6'} contact`} id="contact">
                 <p className="text-sm md:text-base">
                     Xin để lại thông tin chi tiết để chúng tôi hiểu rõ nhu cầu và mong muốn của bạn
                 </p>
 
-                <div className="grid grid-cols-1 gap-4 md:gap-6">
+                <div className={`grid grid-cols-1 ${compact ? 'gap-2 md:gap-3' : 'gap-4 md:gap-6'}`}>
                     {['Họ và tên*', 'Email*', 'Số điện thoại*', 'Diện tích đất và tầng muốn xây*', 'Địa phương muốn xây*'].map(
                         (placeholder, index) => (
                             <input

--- a/src/components/ProjectGallery.js
+++ b/src/components/ProjectGallery.js
@@ -1,0 +1,54 @@
+'use client';
+
+import {useState} from 'react';
+import Image from 'next/image';
+import {Swiper, SwiperSlide} from 'swiper/react';
+import {Thumbs} from 'swiper/modules';
+import 'swiper/css';
+import 'swiper/css/thumbs';
+
+export default function ProjectGallery({images = []}) {
+    const [thumbsSwiper, setThumbsSwiper] = useState(null);
+    if (!images.length) return null;
+    return (
+        <div>
+            <Swiper
+                modules={[Thumbs]}
+                thumbs={{swiper: thumbsSwiper}}
+                spaceBetween={10}
+                className="mb-4"
+            >
+                {images.map((img, idx) => (
+                    <SwiperSlide key={idx}>
+                        <Image
+                            src={img.url}
+                            alt={img.alt || `image-${idx}`}
+                            width={800}
+                            height={600}
+                            className="w-full h-auto object-cover"
+                        />
+                    </SwiperSlide>
+                ))}
+            </Swiper>
+            <Swiper
+                modules={[Thumbs]}
+                onSwiper={setThumbsSwiper}
+                spaceBetween={10}
+                slidesPerView={Math.min(4, images.length)}
+                watchSlidesProgress
+            >
+                {images.map((img, idx) => (
+                    <SwiperSlide key={`thumb-${idx}`}>
+                        <Image
+                            src={img.url}
+                            alt={img.alt || `thumb-${idx}`}
+                            width={150}
+                            height={100}
+                            className="w-full h-full object-cover cursor-pointer"
+                        />
+                    </SwiperSlide>
+                ))}
+            </Swiper>
+        </div>
+    );
+}

--- a/src/components/ProjectGallery.js
+++ b/src/components/ProjectGallery.js
@@ -3,9 +3,10 @@
 import {useState} from 'react';
 import Image from 'next/image';
 import {Swiper, SwiperSlide} from 'swiper/react';
-import {Thumbs} from 'swiper/modules';
+import {Thumbs, Navigation} from 'swiper/modules';
 import 'swiper/css';
 import 'swiper/css/thumbs';
+import 'swiper/css/navigation';
 
 export default function ProjectGallery({images = []}) {
     const [thumbsSwiper, setThumbsSwiper] = useState(null);
@@ -13,9 +14,10 @@ export default function ProjectGallery({images = []}) {
     return (
         <div>
             <Swiper
-                modules={[Thumbs]}
+                modules={[Thumbs, Navigation]}
                 thumbs={{swiper: thumbsSwiper}}
                 spaceBetween={10}
+                navigation
                 className="mb-4"
             >
                 {images.map((img, idx) => (
@@ -34,7 +36,7 @@ export default function ProjectGallery({images = []}) {
                 modules={[Thumbs]}
                 onSwiper={setThumbsSwiper}
                 spaceBetween={10}
-                slidesPerView={Math.min(4, images.length)}
+                slidesPerView={4}
                 watchSlidesProgress
             >
                 {images.map((img, idx) => (
@@ -42,8 +44,8 @@ export default function ProjectGallery({images = []}) {
                         <Image
                             src={img.url}
                             alt={img.alt || `thumb-${idx}`}
-                            width={150}
-                            height={100}
+                            width={80}
+                            height={60}
                             className="w-full h-full object-cover cursor-pointer"
                         />
                     </SwiperSlide>

--- a/src/components/ProjectGallery.js
+++ b/src/components/ProjectGallery.js
@@ -40,13 +40,13 @@ export default function ProjectGallery({images = []}) {
                 watchSlidesProgress
             >
                 {images.map((img, idx) => (
-                    <SwiperSlide key={`thumb-${idx}`}>
+                    <SwiperSlide key={`thumb-${idx}`} className="!w-20 !h-20">
                         <Image
                             src={img.url}
                             alt={img.alt || `thumb-${idx}`}
                             width={80}
-                            height={60}
-                            className="w-full h-full object-cover cursor-pointer"
+                            height={80}
+                            className="object-cover w-full h-full cursor-pointer"
                         />
                     </SwiperSlide>
                 ))}

--- a/src/components/ProjectsGrid.js
+++ b/src/components/ProjectsGrid.js
@@ -1,0 +1,42 @@
+import Image from 'next/image';
+import Link from 'next/link';
+
+export default function ProjectsGrid({projects = []}) {
+    return (
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-3">
+            {projects.length > 0 ? (
+                projects.map(project => (
+                    <Link
+                        key={project._id}
+                        href={`/projects/${project.slug}`}
+                        className="relative bg-white border border-gray-200 overflow-hidden shadow-md hover:shadow-lg transition-shadow duration-300 group"
+                    >
+                        <div className="relative w-full h-80 overflow-hidden">
+                            {project.image && (
+                                <Image
+                                    src={project.image}
+                                    alt={project.title}
+                                    width={700}
+                                    height={700}
+                                    className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
+                                />
+                            )}
+                            <div className="absolute inset-0 flex flex-col items-center justify-center bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity duration-500">
+                                <h3 className="text-lg font-semibold text-white text-center translate-y-4 group-hover:translate-y-0 transition-transform duration-500">
+                                    {project.title}
+                                </h3>
+                                {project.shortDescription && (
+                                    <p className="text-md text-white text-center translate-y-4 group-hover:translate-y-0 transition-transform duration-500 mt-2 px-4">
+                                        {project.shortDescription}
+                                    </p>
+                                )}
+                            </div>
+                        </div>
+                    </Link>
+                ))
+            ) : (
+                <p className="text-center text-gray-600 col-span-full">Không tìm thấy dự án nào.</p>
+            )}
+        </div>
+    );
+}

--- a/src/sanity/lib/queries.js
+++ b/src/sanity/lib/queries.js
@@ -106,6 +106,9 @@ export const projectSlugsQuery = `*[_type == "projectDetail" && defined(slug.cur
 export const projectBySlugQuery = `*[_type == "projectDetail" && slug.current == $slug][0]{
   title,
   information,
+  category,
+  isCompleted,
+  _createdAt,
   "slug": slug.current,
   gallery[]{
     "url": asset->url,
@@ -120,5 +123,22 @@ export const projectBySlugQuery = `*[_type == "projectDetail" && slug.current ==
     },
     imageSubtitle
   }
+}`;
+
+export const projectsQuery = `*[_type == "projectDetail" && (!defined(isCompleted) || isCompleted == $isCompleted)]{
+  _id,
+  title,
+  "slug": slug.current,
+  "image": gallery[0].asset->url,
+  "shortDescription": information.shortDescription,
+  category,
+  isCompleted,
+  _createdAt
+}`;
+
+export const siteSettingsQuery = `*[_type == "siteSettings"][0]{
+  facebook,
+  zalo,
+  youtube
 }`;
 

--- a/src/sanity/lib/queries.js
+++ b/src/sanity/lib/queries.js
@@ -125,7 +125,18 @@ export const projectBySlugQuery = `*[_type == "projectDetail" && slug.current ==
   }
 }`;
 
-export const projectsQuery = `*[_type == "projectDetail" && (!defined(isCompleted) || isCompleted == $isCompleted)]{
+export const projectsQuery = `*[_type == "projectDetail" && isCompleted != true]{
+  _id,
+  title,
+  "slug": slug.current,
+  "image": gallery[0].asset->url,
+  "shortDescription": information.shortDescription,
+  category,
+  isCompleted,
+  _createdAt
+}`;
+
+export const completedProjectsQuery = `*[_type == "projectDetail" && isCompleted == true]{
   _id,
   title,
   "slug": slug.current,

--- a/src/sanity/schemaTypes/index.js
+++ b/src/sanity/schemaTypes/index.js
@@ -16,6 +16,7 @@ import aboutHeroSection from "@/sanity/schemaTypes/aboutHeroSection";
 import teamSection from "@/sanity/schemaTypes/teamSection";
 
 import projectDetail from "@/sanity/schemaTypes/projectDetail";
+import siteSettings from "@/sanity/schemaTypes/siteSettings";
 
 
 export const schemas = {
@@ -37,6 +38,7 @@ export const schemas = {
         aboutHeroSection,
         teamSection,
         projectDetail,
+        siteSettings,
 
     ],
 }

--- a/src/sanity/schemaTypes/projectDetail.js
+++ b/src/sanity/schemaTypes/projectDetail.js
@@ -33,6 +33,17 @@ export default {
             validation: Rule => Rule.required()
         },
         {
+            name: 'category',
+            title: 'Danh mục',
+            type: 'string'
+        },
+        {
+            name: 'isCompleted',
+            title: 'Thi công thực tế',
+            type: 'boolean',
+            initialValue: false
+        },
+        {
             name: 'gallery',
             title: 'Thư viện ảnh',
             type: 'array',

--- a/src/sanity/schemaTypes/projectDetail.js
+++ b/src/sanity/schemaTypes/projectDetail.js
@@ -35,7 +35,17 @@ export default {
         {
             name: 'category',
             title: 'Danh mục',
-            type: 'string'
+            type: 'string',
+            options: {
+                list: [
+                    { title: 'Biệt thự', value: 'mansion' },
+                    { title: 'Nhà phố', value: 'urbanHouse' },
+                    { title: 'Nhà vườn', value: 'countryHouse' },
+                    { title: 'Nhà tân cổ điển', value: 'neoClassicHouse' },
+                    { title: 'Công trình dịch vụ', value: 'serviceBuilding' },
+                ],
+            },
+            validation: Rule => Rule.required()
         },
         {
             name: 'isCompleted',

--- a/src/sanity/schemaTypes/siteSettings.js
+++ b/src/sanity/schemaTypes/siteSettings.js
@@ -1,0 +1,10 @@
+export default {
+    name: 'siteSettings',
+    title: 'Cài đặt trang',
+    type: 'document',
+    fields: [
+        { name: 'facebook', title: 'Facebook', type: 'url' },
+        { name: 'zalo', title: 'Zalo', type: 'url' },
+        { name: 'youtube', title: 'Youtube', type: 'url' },
+    ]
+}


### PR DESCRIPTION
## Summary
- show breadcrumb, social links, date and sticky contact form on project detail
- add gallery carousel component and compact contact form
- fetch projects and completed projects from Sanity with new schema and queries

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a02bee06108333859c2d35e801bf71