### PR TITLE
feat: add news pages and schema

### DIFF
--- a/src/app/(site)/news/[slug]/page.js
+++ b/src/app/(site)/news/[slug]/page.js
@@ -1,0 +1,138 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { client } from '@/sanity/lib/client';
+import { newsBySlugQuery, newsSlugsQuery, contactFormQuery, siteSettingsQuery } from '@/sanity/lib/queries';
+import ContactForm from '@/components/ContactForm';
+import { Facebook, Youtube, Share2 } from 'lucide-react';
+
+export async function generateStaticParams() {
+    const slugs = await client.fetch(newsSlugsQuery);
+    return slugs.map(({ slug }) => ({ slug }));
+}
+
+export default async function NewsDetailPage({ params }) {
+    const { slug } = await params;
+    const news = await client.fetch(newsBySlugQuery, { slug });
+    if (!news) {
+        notFound();
+    }
+    const contactData = await client.fetch(contactFormQuery);
+    const siteSettings = await client.fetch(siteSettingsQuery);
+
+    const { title, sections, category, _createdAt } = news;
+    const categoryLabels = {
+        news: 'Tin tức',
+        activities: 'Hoạt động công ty',
+    };
+
+    return (
+        <div className="min-h-screen bg-[#272727] text-white pt-26">
+            <div className="container mx-auto py-10 px-6">
+                <nav className="text-sm text-gray-400 mb-4">
+                    <Link href="/" className="hover:underline">Trang chủ</Link>
+                    <span className="mx-1">&gt;</span>
+                    <Link href="/news" className="hover:underline">Tin tức</Link>
+                    {category && (
+                        <>
+                            <span className="mx-1">&gt;</span>
+                            <span>{categoryLabels[category] || category}</span>
+                        </>
+                    )}
+                    <span className="mx-1">&gt;</span>
+                    <span className="text-white">{title}</span>
+                </nav>
+                <div className="grid md:grid-cols-3 gap-8">
+                    <div className="md:col-span-2">
+                        <h1 className="text-3xl font-bold mb-8">{title}</h1>
+                        <div className="flex items-center gap-4 mb-6">
+                            {siteSettings?.facebook && (
+                                <a href={siteSettings.facebook} target="_blank" rel="noopener noreferrer" aria-label="Facebook">
+                                    <Facebook className="w-5 h-5" />
+                                </a>
+                            )}
+                            {siteSettings?.zalo && (
+                                <a href={siteSettings.zalo} target="_blank" rel="noopener noreferrer" aria-label="Zalo">
+                                    <Image src="/images/Icon_of_Zalo.svg" alt="Zalo" width={20} height={20} />
+                                </a>
+                            )}
+                            {siteSettings?.youtube && (
+                                <a href={siteSettings.youtube} target="_blank" rel="noopener noreferrer" aria-label="YouTube">
+                                    <Youtube className="w-5 h-5" />
+                                </a>
+                            )}
+                            <span className="text-sm text-gray-400">{new Date(_createdAt).toLocaleDateString('vi-VN')}</span>
+                        </div>
+                        {sections && sections.length > 0 && (
+                            <div className="space-y-12">
+                                {sections.map((section, idx) => (
+                                    <div key={idx}>
+                                        {section.header && (
+                                            <h2 className="text-2xl font-semibold mb-4">{section.header}</h2>
+                                        )}
+                                        {section.content && (
+                                            <p className="mb-4 whitespace-pre-line">{section.content}</p>
+                                        )}
+                                        {section.images && section.images.length > 0 && (
+                                            <div className="space-y-4">
+                                                {section.images.map((img, i) => (
+                                                    <Image
+                                                        key={i}
+                                                        src={img.url}
+                                                        alt={img.alt || title}
+                                                        width={800}
+                                                        height={600}
+                                                        className="w-full h-auto"
+                                                    />
+                                                ))}
+                                            </div>
+                                        )}
+                                    </div>
+                                ))}
+                            </div>
+                        )}
+                        <div className="mt-12 pt-8 border-t border-gray-600">
+                            <h3 className="text-lg font-semibold mb-4 flex items-center gap-2">
+                                <Share2 className="w-5 h-5" />
+                                Chia sẻ bài viết
+                            </h3>
+                            <div className="flex gap-3">
+                                <a
+                                    href={`https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(`${process.env.NEXT_PUBLIC_SITE_URL || 'https://yourdomain.com'}/news/${slug}`)}&quote=${encodeURIComponent(`Xem tin tức: ${title}`)}`}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="relative group flex items-center justify-center w-10 h-10 hover:rounded-full transition-colors"
+                                    aria-label="Chia sẻ lên Facebook"
+                                    title="Chia sẻ Facebook"
+                                >
+                                    <Facebook className="w-5 h-5" />
+                                    <span className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-2 py-1 text-xs bg-black text-white rounded opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap">
+                                        Chia sẻ Facebook
+                                    </span>
+                                </a>
+                                <a
+                                    href={`https://zalo.me/share?url=${encodeURIComponent(`${process.env.NEXT_PUBLIC_SITE_URL || 'https://yourdomain.com'}/news/${slug}`)}&title=${encodeURIComponent(`Xem tin tức: ${title}`)}`}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="relative group flex items-center justify-center w-10 h-10 hover:rounded-full transition-colors"
+                                    aria-label="Chia sẻ lên Zalo"
+                                    title="Chia sẻ Zalo"
+                                >
+                                    <Image src="/images/Icon_of_Zalo.svg" alt="Zalo" width={20} height={20} />
+                                    <span className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-2 py-1 text-xs bg-black text-white rounded opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap">
+                                        Chia sẻ Zalo
+                                    </span>
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                    <div className="md:col-span-1">
+                        <div className="sticky top-18">
+                            <ContactForm data={contactData} sidebarMode={true} />
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/app/(site)/news/page.js
+++ b/src/app/(site)/news/page.js
@@ -1,9 +1,16 @@
-import WhyChooseUs from "@/components/WhyChooseUs";
+import { client } from '@/sanity/lib/client';
+import { newsQuery } from '@/sanity/lib/queries';
+import Banner from '@/components/ui/banner';
+import NewsFilter from '@/components/NewsFilter';
 
-export default function  News(){
-    return(
-        <div className="bg-[#272727] py-70">
-
+export default async function NewsPage() {
+    const news = await client.fetch(newsQuery);
+    return (
+        <div className="min-h-screen bg-[#272727] text-center">
+            <Banner title="Tin tức" />
+            <div className="px-6 md:px-10 container mx-auto pb-30">
+                <NewsFilter news={news} />
+            </div>
         </div>
-    )
+    );
 }

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -22,6 +22,7 @@ export default function Navbar() {
         { name: "DỊCH VỤ", href: "/services" },
         { name: "DỰ ÁN", href: "/projects", dropdown: true, chevron: true },
         { name: "THI CÔNG THỰC TẾ", href: "/completed-projects", dropdown: true, chevron: true },
+        { name: "TIN TỨC", href: "/news" },
         { name: "LIÊN HỆ", href: "/contact" },
     ]
 

--- a/src/components/NewsFilter.js
+++ b/src/components/NewsFilter.js
@@ -1,0 +1,125 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import NewsGrid from './NewsGrid';
+import SearchBar from './SearchBar';
+import CategoryTags from './CategoryTags';
+import Pagination from './Pagination';
+import { SearchX } from 'lucide-react';
+
+const categories = [
+    { value: 'all', title: 'Tất cả' },
+    { value: 'news', title: 'Tin tức' },
+    { value: 'activities', title: 'Hoạt động công ty' },
+];
+
+const ITEMS_PER_PAGE = 12;
+
+export default function NewsFilter({ news }) {
+    const [filteredNews, setFilteredNews] = useState(news);
+    const [selectedCategory, setSelectedCategory] = useState('all');
+    const [searchTerm, setSearchTerm] = useState('');
+    const [currentPage, setCurrentPage] = useState(1);
+    const [paginatedNews, setPaginatedNews] = useState([]);
+
+    useEffect(() => {
+        let filtered = news;
+        if (selectedCategory !== 'all') {
+            filtered = filtered.filter(item => item.category === selectedCategory);
+        }
+        if (searchTerm) {
+            const searchLower = searchTerm.toLowerCase();
+            filtered = filtered.filter(item =>
+                item.title.toLowerCase().includes(searchLower) ||
+                (item.excerpt && item.excerpt.toLowerCase().includes(searchLower))
+            );
+        }
+        setFilteredNews(filtered);
+        setCurrentPage(1);
+    }, [news, selectedCategory, searchTerm]);
+
+    useEffect(() => {
+        const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
+        const endIndex = startIndex + ITEMS_PER_PAGE;
+        setPaginatedNews(filteredNews.slice(startIndex, endIndex));
+    }, [filteredNews, currentPage]);
+
+    const totalPages = Math.ceil(filteredNews.length / ITEMS_PER_PAGE);
+
+    const handleCategoryChange = (category) => {
+        setSelectedCategory(category);
+    };
+
+    const handleSearchChange = (value) => {
+        setSearchTerm(value);
+    };
+
+    const handlePageChange = (page) => {
+        setCurrentPage(page);
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+    };
+
+    const resetFilters = () => {
+        setSelectedCategory('all');
+        setSearchTerm('');
+        setCurrentPage(1);
+    };
+
+    return (
+        <>
+            <div className="mb-12 space-y-6">
+                <SearchBar
+                    searchTerm={searchTerm}
+                    onSearchChange={handleSearchChange}
+                    placeholder="Tìm kiếm tin tức..."
+                />
+                <CategoryTags
+                    categories={categories}
+                    selectedCategory={selectedCategory}
+                    onCategoryChange={handleCategoryChange}
+                />
+                <div className="text-center text-gray-400">
+                    {searchTerm || selectedCategory !== 'all' ? (
+                        <span>
+                            Hiển thị {((currentPage - 1) * ITEMS_PER_PAGE) + 1}-{Math.min(currentPage * ITEMS_PER_PAGE, filteredNews.length)} trong {filteredNews.length} / {news.length} bài viết
+                            {searchTerm && (
+                                <span> cho "{searchTerm}"</span>
+                            )}
+                            {selectedCategory !== 'all' && (
+                                <span> trong danh mục "{categories.find(cat => cat.value === selectedCategory)?.title}"</span>
+                            )}
+                        </span>
+                    ) : (
+                        <span>
+                            Hiển thị {((currentPage - 1) * ITEMS_PER_PAGE) + 1}-{Math.min(currentPage * ITEMS_PER_PAGE, news.length)} trong tổng cộng {news.length} bài viết
+                        </span>
+                    )}
+                </div>
+            </div>
+            <NewsGrid news={paginatedNews} />
+            {totalPages > 1 && (
+                <div className="mt-12">
+                    <Pagination
+                        currentPage={currentPage}
+                        totalPages={totalPages}
+                        onPageChange={handlePageChange}
+                    />
+                </div>
+            )}
+            {filteredNews.length === 0 && news.length > 0 && (
+                <div className="text-center py-8">
+                    <div className="text-gray-400 mb-4">
+                        <SearchX size={40} className="mx-auto" />
+                    </div>
+                    <h3 className="text-xl font-semibold text-gray-300 mb-6">Không tìm thấy bài viết nào</h3>
+                    <button
+                        onClick={resetFilters}
+                        className="px-6 py-2 bg-amber-400 text-white rounded-lg hover:bg-amber-500 transition-colors"
+                    >
+                        Xóa tất cả bộ lọc
+                    </button>
+                </div>
+            )}
+        </>
+    );
+}

--- a/src/components/NewsGrid.js
+++ b/src/components/NewsGrid.js
@@ -1,0 +1,43 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import { MoveUpRight } from 'lucide-react';
+
+export default function NewsGrid({ news = [] }) {
+    return (
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+            {news.length > 0 && news.map(item => (
+                <div
+                    key={item._id}
+                    className="bg-white rounded-lg overflow-hidden shadow-sm hover:shadow-md transition-shadow duration-300 group"
+                >
+                    <div className="relative w-full h-64 overflow-hidden">
+                        {item.image && (
+                            <Image
+                                src={item.image}
+                                alt={item.title}
+                                width={400}
+                                height={300}
+                                className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105"
+                            />
+                        )}
+                    </div>
+                    <div className="p-6 space-y-3 text-left">
+                        <h3 className="text-lg font-semibold text-gray-900 leading-tight line-clamp-2">
+                            {item.title}
+                        </h3>
+                        {item.excerpt && (
+                            <p className="text-sm text-gray-600 line-clamp-2">{item.excerpt}</p>
+                        )}
+                        <Link
+                            href={`/news/${item.slug}`}
+                            className="inline-flex items-center gap-2 bg-amber-400 hover:bg-amber-500 text-black font-medium px-4 py-2 rounded transition-colors duration-200 mt-4"
+                        >
+                            Xem thêm
+                            <span><MoveUpRight size={16} strokeWidth={3} /></span>
+                        </Link>
+                    </div>
+                </div>
+            ))}
+        </div>
+    );
+}

--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -1,6 +1,6 @@
 'use client';
 
-export default function SearchBar({ searchTerm, onSearchChange }) {
+export default function SearchBar({ searchTerm, onSearchChange, placeholder = 'Tìm kiếm dự án...' }) {
     const handleChange = (e) => {
         onSearchChange(e.target.value);
     };
@@ -18,7 +18,7 @@ export default function SearchBar({ searchTerm, onSearchChange }) {
             </div>
             <input
                 type="text"
-                placeholder="Tìm kiếm dự án..."
+                placeholder={placeholder}
                 value={searchTerm}
                 onChange={handleChange}
                 className="block w-full pl-10 pr-10 py-3 border border-gray-600 rounded-lg bg-gray-800 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-amber-400 focus:border-transparent"

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -10,7 +10,9 @@ export const getCategoryTitle = (categoryValue) => {
     'urbanHouse': 'Nhà phố',
     'countryHouse': 'Nhà vườn',
     'neoClassicHouse': 'Nhà tân cổ điển',
-    'serviceBuilding': 'Công trình dịch vụ'
+    'serviceBuilding': 'Công trình dịch vụ',
+    'news': 'Tin tức',
+    'activities': 'Hoạt động công ty'
   };
   return categoryMap[categoryValue] || categoryValue;
 };

--- a/src/sanity/lib/queries.js
+++ b/src/sanity/lib/queries.js
@@ -159,3 +159,32 @@ export const siteSettingsQuery = `*[_type == "siteSettings"][0]{
   youtube
 }`;
 
+export const newsSlugsQuery = `*[_type == "news" && defined(slug.current)]{
+  "slug": slug.current
+}`;
+
+export const newsBySlugQuery = `*[_type == "news" && slug.current == $slug][0]{
+  title,
+  category,
+  _createdAt,
+  "slug": slug.current,
+  sections[]{
+    header,
+    content,
+    images[]{
+      "url": asset->url,
+      alt
+    }
+  }
+}`;
+
+export const newsQuery = `*[_type == "news"] | order(_createdAt desc){
+  _id,
+  title,
+  "slug": slug.current,
+  "image": thumbnail.asset->url,
+  excerpt,
+  category,
+  _createdAt
+}`;
+

--- a/src/sanity/schemaTypes/index.js
+++ b/src/sanity/schemaTypes/index.js
@@ -17,6 +17,7 @@ import teamSection from "@/sanity/schemaTypes/teamSection";
 
 import projectDetail from "@/sanity/schemaTypes/projectDetail";
 import siteSettings from "@/sanity/schemaTypes/siteSettings";
+import news from "@/sanity/schemaTypes/news";
 
 
 export const schemas = {
@@ -39,6 +40,7 @@ export const schemas = {
         teamSection,
         projectDetail,
         siteSettings,
+        news,
 
     ],
 }

--- a/src/sanity/schemaTypes/news.js
+++ b/src/sanity/schemaTypes/news.js
@@ -1,0 +1,106 @@
+const customSlugify = (input) => {
+    let slug = input.trim();
+    if (slug.startsWith('http')) {
+        try {
+            const url = new URL(slug);
+            if (url.hostname !== 'nhadepquangnam.vn') {
+                return 'invalid-domain';
+            }
+            slug = url.pathname.replace(/^\/news\//, '').replace(/^\/+|\/+$/g, '');
+        } catch {
+            return 'invalid-domain';
+        }
+    }
+    return slug
+        .toString()
+        .toLowerCase()
+        .replace(/[^a-z0-9-]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+};
+
+export default {
+    name: 'news',
+    title: 'Tin tức',
+    type: 'document',
+    fields: [
+        {
+            name: 'title',
+            title: 'Tiêu đề',
+            type: 'string',
+            validation: Rule => Rule.required(),
+        },
+        {
+            name: 'slug',
+            title: 'Slug',
+            type: 'slug',
+            options: {
+                source: 'title',
+                maxLength: 96,
+                slugify: customSlugify,
+            },
+            validation: Rule => Rule.required().custom(slug => {
+                if (slug?.current === 'invalid-domain') {
+                    return 'URL phải thuộc tên miền nhadepquangnam.vn';
+                }
+                return true;
+            }),
+        },
+        {
+            name: 'category',
+            title: 'Danh mục',
+            type: 'string',
+            options: {
+                list: [
+                    { title: 'Tin tức', value: 'news' },
+                    { title: 'Hoạt động công ty', value: 'activities' },
+                ],
+            },
+            validation: Rule => Rule.required(),
+        },
+        {
+            name: 'thumbnail',
+            title: 'Thumbnail',
+            type: 'image',
+            options: { hotspot: true },
+            fields: [{ name: 'alt', title: 'Alt', type: 'string', description: 'Tự động tạo từ tiêu đề nếu bỏ trống' }],
+        },
+        {
+            name: 'excerpt',
+            title: 'Mô tả ngắn',
+            type: 'text',
+        },
+        {
+            name: 'sections',
+            title: 'Các phần',
+            type: 'array',
+            of: [
+                {
+                    type: 'object',
+                    fields: [
+                        { name: 'header', title: 'Tiêu đề phần', type: 'string' },
+                        { name: 'content', title: 'Nội dung', type: 'text' },
+                        {
+                            name: 'images',
+                            title: 'Hình ảnh',
+                            type: 'array',
+                            of: [
+                                {
+                                    type: 'image',
+                                    options: { hotspot: true },
+                                    fields: [
+                                        {
+                                            name: 'alt',
+                                            title: 'Alt',
+                                            type: 'string',
+                                            description: 'Tự động tạo từ tiêu đề nếu bỏ trống',
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        },
+    ],
+};


### PR DESCRIPTION
## Summary
- add Sanity news schema with slug validation and categories
- implement news listing and detail pages with filters and sections
- include news in navbar and shared utilities

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0df6190488333921d492951ad0bc9