### PR TITLE
Integrate next-seo for SEO configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "next": "15.3.5",
     "next-sanity": "^9.12.3",
     "next-sanity-image": "^6.2.0",
+    "next-seo": "^6.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "sanity": "^3.99.0",

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -1,6 +1,8 @@
 // src/app/layout.js (minimal root)
 import "./globals.css";
 import {mulish} from "@/app/fonts";
+import {DefaultSeo} from "next-seo";
+import SEO from "@/seo.config";
 
 
 export const metadata = {
@@ -12,6 +14,7 @@ export default function RootLayout({children}) {
     return (
         <html lang="en" suppressHydrationWarning className={`${mulish.className} antialiased`}>
         <body suppressHydrationWarning>
+        <DefaultSeo {...SEO} />
         {children}
         </body>
         </html>

--- a/src/seo.config.js
+++ b/src/seo.config.js
@@ -1,0 +1,13 @@
+const SEO = {
+  titleTemplate: '%s | Nhà đẹp Quảng Nam',
+  defaultTitle: 'Nhà đẹp Quảng Nam',
+  description: 'Nhà đẹp Quảng Nam - Kiến tạo không gian sống hiện đại với phong cách tối giản và tinh tế',
+  openGraph: {
+    type: 'website',
+    locale: 'vi_VN',
+    url: 'https://nhadepquangnam.com',
+    siteName: 'Nhà đẹp Quảng Nam',
+  },
+};
+
+export default SEO;


### PR DESCRIPTION
## Summary
- add `next-seo` dependency and default SEO configuration
- apply global `<DefaultSeo>` in root layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0ef560ab8833397aeb638204fc33b