### PR TITLE
feat: wire about sections to sanity

### DIFF
--- a/src/app/(site)/about/page.js
+++ b/src/app/(site)/about/page.js
@@ -18,9 +18,9 @@ export default async function AboutPage() {
             <AboutHeroSection data={data?.heroSection}/>
             <TeamSection data={data?.teamSection}/>
             {/*Office pictures*/}
-            <OfficePictures/>
-            <Commitments/>
-            <CoreValues/>
+            <OfficePictures data={data?.officePictures}/>
+            <Commitments data={data?.commitments}/>
+            <CoreValues data={data?.coreValues}/>
         </div>
     );
 }

--- a/src/components/Commitments.js
+++ b/src/components/Commitments.js
@@ -2,34 +2,34 @@ import Image from "next/image";
 import { fancyFont } from "@/app/fonts";
 
 // Commitment data
-const commitmentItems = [
+const fallbackItems = [
     {
         id: 1,
-        icon: "/images/Artboard-5.png",
+        iconUrl: "/images/Artboard-5.png",
         title: "KHÔNG sử dụng vật tư kém chất lượng",
         description: "Chỉ sử dụng vật liệu chất lượng cao, đạt tiêu chuẩn nghiêm ngặt, đảm bảo độ bền và hiệu quả lâu dài"
     },
     {
         id: 2,
-        icon: "/images/Artboard-6.png",
+        iconUrl: "/images/Artboard-6.png",
         title: "KHÔNG sử dụng vật tư khác với báo giá",
         description: "Giá cả minh bạch theo đúng thông số thực tế, không có chi phí ẩn hay báo giá sai lệch"
     },
     {
         id: 3,
-        icon: "/images/Artboard-7.png",
+        iconUrl: "/images/Artboard-7.png",
         title: "KHÔNG cắt giảm vật tư, thi công đủ và đúng tiêu chuẩn",
         description: "Mọi công trình được thực hiện với đủ khối lượng vật tư và phương pháp thi công đúng kỹ thuật, tuân thủ tiêu chuẩn không cắt giảm"
     },
     {
         id: 4,
-        icon: "/images/Artboard-8.png",
+        iconUrl: "/images/Artboard-8.png",
         title: "KHÔNG bán thầu, kiểm soát chất lượng từ A-Z",
         description: "Giám sát chất lượng toàn bộ quy trình từ đầu đến cuối, loại bỏ rủi ro bán thầu, đảm bảo chất lượng thống nhất"
     },
     {
         id: 5,
-        icon: "/images/Artboard-9.png",
+        iconUrl: "/images/Artboard-9.png",
         title: "KHÔNG giấu giếm, minh bạch trong từng khâu thi công",
         description: "Mọi giai đoạn thi công được thực hiện công khai, khách hàng có thể theo dõi tiến độ và phương pháp mọi lúc"
     }
@@ -57,10 +57,11 @@ const CommitmentItem = ({ icon, title, description, isLastInColumn = false }) =>
 );
 
 // Main component
-export default function Commitments() {
+export default function Commitments({data}) {
+    const items = data?.items?.length ? data.items : fallbackItems;
     // Split items into two columns
-    const leftColumnItems = commitmentItems.slice(0, 3);
-    const rightColumnItems = commitmentItems.slice(3, 5);
+    const leftColumnItems = items.slice(0, 3);
+    const rightColumnItems = items.slice(3, 5);
 
     return (
         <section>
@@ -90,7 +91,7 @@ export default function Commitments() {
                             {leftColumnItems.map((item, index) => (
                                 <CommitmentItem
                                     key={`left-${item.id || index}`}
-                                    icon={item.icon}
+                                    icon={item.iconUrl || item.icon}
                                     title={item.title}
                                     description={item.description}
                                     isLastInColumn={index === leftColumnItems.length - 1}
@@ -106,7 +107,7 @@ export default function Commitments() {
                             {rightColumnItems.map((item, index) => (
                                 <CommitmentItem
                                     key={`right-${item.id || index}`}
-                                    icon={item.icon}
+                                    icon={item.iconUrl || item.icon}
                                     title={item.title}
                                     description={item.description}
                                     isLastInColumn={index === rightColumnItems.length - 1}

--- a/src/components/CoreValues.js
+++ b/src/components/CoreValues.js
@@ -1,34 +1,35 @@
 import Image from "next/image";
 
-const coreValues = [
+const fallbackValues = [
     {
-        img: "/images/responsibility.png",
+        iconUrl: "/images/responsibility.png",
         title: "TRÁCH NHIỆM",
         description: "Không phải cứ bàn giao xong là hết nghĩa vụ, mà là đảm bảo công trình ấy thực sự đáng sống, đáng tin cậy trong nhiều năm sau."
     },
     {
-        img: "/images/design-thinking.png",
+        iconUrl: "/images/design-thinking.png",
         title: "ĐỔI MỚI, SÁNG TẠO",
         description: "Với phương châm không ngừng phát triển Nhà Đẹp Quảng Nam luôn tập trung cải tiến toàn diện để mang đến dịch vụ tốt nhất."
     },
     {
-        img: "/images/trust.png",
+        iconUrl: "/images/trust.png",
         title: "TRUNG THỰC",
         description: "Trong quá trình thi công xây dựng chúng tôi tuân thủ đạo đức nghề nghiệp, không gian dối hay làm trái nguyên tắc."
     },
     {
-        img: "/images/compass.png",
+        iconUrl: "/images/compass.png",
         title: "TÔN TRỌNG",
         description: "Chúng tôi không đơn thuần là đơn vị thi công theo yêu cầu, mà còn là thấu hiểu mong muốn của khách hàng."
     },
     {
-        img: "/images/honest.png",
+        iconUrl: "/images/honest.png",
         title: "ĐOÀN KẾT",
         description: "Trong phong cách làm việc Nhà Đẹp Quảng Nam luôn ưu tiên tư vấn trung thực, tập trung vào giá trị thực tế cho khách hàng."
     }
 ];
 
-export default function CoreValues() {
+export default function CoreValues({data}) {
+    const values = data?.values?.length ? data.values : fallbackValues;
     return (
         <section className="py-16 px-4 bg-white">
             <div className="max-w-7xl mx-auto">
@@ -41,7 +42,7 @@ export default function CoreValues() {
 
                 {/* Values Grid */}
                 <div className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-5 gap-8 items-start">
-                    {coreValues.map((item, index) => (
+                    {values.map((item, index) => (
                         <div key={index} className="flex flex-col items-center text-center group">
                             {/* Icon Container */}
                             <div className="relative mb-6">
@@ -49,7 +50,7 @@ export default function CoreValues() {
                                 <div
                                     className="w-32 h-32 bg-orange-400 rounded-full flex items-center justify-center group-hover:bg-orange-300 transition-all duration-300">
                                     <Image
-                                        src={item.img}
+                                        src={item.iconUrl || item.img}
                                         alt={item.title}
                                         width={60}
                                         height={60}

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -14,18 +14,9 @@ const fallback = {
         email: 'nhadepquangnam@gmail.com',
         phones: ['0914.353.808', '0905.659.036'],
     },
-    otherBranches: [
-        {
-            city: 'Đà Nẵng',
-            address: '20 Đống Đa, P. Thuận Phước, Q. Hải Châu, TP. Đà Nẵng',
-            phones: ['0369 151 115 (Ms. Mai)'],
-        },
-        {
-            city: 'Hà Nội',
-            address:
-                'L5.16 Khu nhà ở liền kề Hải Ngân, thôn Nội, xã Thanh Liệt, H. Thanh Trì, TP. Hà Nội',
-            phones: ['0358 232 514 (Mr. Hiếu)'],
-        },
+    footerQuotes: [
+        'Với ước mơ tạo ra những ngôi nhà thật đẹp chàng kĩ sư trẻ Nguyên Tương Tổng Giám Đốc tại công ty Nhà Đẹp Quảng Nam chia sẻ.',
+        '"Chúng tôi không chỉ đơn thuần xây dựng những công trình, mà còn kiến tạo nên những tổ ấm - nơi gia đình sum vầy, nơi nuôi dưỡng những khoảnh khắc hạnh phúc."'
     ],
 };
 
@@ -36,10 +27,10 @@ export default function Footer({data}) {
     const ctaText = content.ctaText || fallback.ctaText;
     const description = content.description || fallback.description;
     const mainBranch = content.mainBranch || fallback.mainBranch;
-    const otherBranches =
-        Array.isArray(content.otherBranches) && content.otherBranches.length > 0
-            ? content.otherBranches
-            : fallback.otherBranches;
+    const footerQuotes =
+        Array.isArray(content.footerQuotes) && content.footerQuotes.length > 0
+            ? content.footerQuotes
+            : fallback.footerQuotes;
 
     const circleSize = '400px';
 
@@ -101,16 +92,13 @@ export default function Footer({data}) {
                                 )}
                             </div>
 
-                            {/* Columns 2 & 3: Other branches */}
+                            {/* Quotes */}
                             <div className="w-full">
-                                <p className="italic">
-                                    Với ước mơ tạo ra những ngôi nhà thật đẹp chàng kĩ sư trẻ Nguyên Tương Tổng Giám Đốc tại
-                                    công ty Nhà Đẹp Quảng Nam chia sẻ.
-                                </p>
-                                <p>
-                                    "Chúng tôi không chỉ đơn thuần xây dựng những công trình, mà còn kiến tạo nên những tổ
-                                    ấm - nơi gia đình sum vầy, nơi nuôi dưỡng những khoảnh khắc hạnh phúc."
-                                </p>
+                                {footerQuotes.map((quote, index) => (
+                                    <p key={index} className={index === 0 ? 'italic' : ''}>
+                                        {quote}
+                                    </p>
+                                ))}
                             </div>
                         </div>
                     </div>

--- a/src/components/OfficePictures.js
+++ b/src/components/OfficePictures.js
@@ -1,27 +1,33 @@
 import Image from "next/image";
 
-export default function OfficePictures(){
-    return(
+const fallbackImages = [
+    { imageUrl: "/images/office1.jpg" },
+    { imageUrl: "/images/Thiet-ke-chua-co-ten-7.jpg" },
+    { imageUrl: "/images/Thiet-ke-chua-co-ten-7.jpg" }
+];
+
+export default function OfficePictures({data}) {
+    const images = data?.images?.length ? data.images : fallbackImages;
+    return (
         <section className="pt-12">
             <div className="w-full mx-auto text-center">
                 <h2 className="text-white text-3xl font-bold my-20 p-4 inline-block border-2 border-white">
                     HÌNH ẢNH VĂN PHÒNG
                 </h2>
                 <div className="flex justify-center">
-                    <div className="overflow-hidden">
-                        <Image width={300} height={500} src="/images/office1.jpg" alt="van phong"
-                               className="object-cover w-full h-full transition-transform duration-300 ease-in-out hover:scale-110"/>
-                    </div>
-                    <div className="overflow-hidden">
-                        <Image width={300} height={500} src="/images/Thiet-ke-chua-co-ten-7.jpg" alt="van phong"
-                               className="w-full h-full object-cover transition-transform duration-300 ease-in-out hover:scale-110"/>
-                    </div>
-                    <div className="overflow-hidden">
-                        <Image width={300} height={500} src="/images/Thiet-ke-chua-co-ten-7.jpg" alt="van phong"
-                               className="w-full object-cover transition-transform duration-300 ease-in-out hover:scale-110"/>
-                    </div>
+                    {images.map((img, idx) => (
+                        <div key={idx} className="overflow-hidden">
+                            <Image
+                                width={300}
+                                height={500}
+                                src={img.imageUrl || img}
+                                alt="van phong"
+                                className="object-cover w-full h-full transition-transform duration-300 ease-in-out hover:scale-110"
+                            />
+                        </div>
+                    ))}
                 </div>
             </div>
         </section>
-    )
+    );
 }

--- a/src/components/ServiceSections.js
+++ b/src/components/ServiceSections.js
@@ -2,6 +2,7 @@
 
 import Image from 'next/image';
 import {useEffect} from 'react';
+import Link from "next/link";
 
 export default function ServiceSections({services}) {
     useEffect(() => {
@@ -62,12 +63,12 @@ export default function ServiceSections({services}) {
                             {service.title}
                         </h2>
                         <p className="text-white mb-4">{service.description}</p>
-                        <a
-                            href={`/services/${service.slug || service.id}`}
+                        <Link
+                            href='/contact'
                             className="w-fit inline-block px-4 py-2 border border-orange-400 bg-white text-orange-400 text-center hover:text-white hover:!bg-orange-400 font-semibold rounded-full duration-200 text-lg"
                         >
                             Liên hệ
-                        </a>
+                        </Link>
                     </div>
                     <div className="w-full md:w-1/2 p-4 service-image relative">
                         <Image

--- a/src/sanity/lib/queries.js
+++ b/src/sanity/lib/queries.js
@@ -46,13 +46,9 @@ export const footerQuery = `*[_type == "footerSettings"][0]{
     email,
     phones
   },
-  otherBranches[]{
-    city,
-    address,
-    phones
-  }
+  footerQuotes
  }
- `;
+`;
 
 export const aboutPageQuery = `*[_type == "aboutPage"][0]{
   heroSection{
@@ -73,6 +69,25 @@ export const aboutPageQuery = `*[_type == "aboutPage"][0]{
       name,
       title,
       "thumbnailUrl": thumbnail.asset->url
+    }
+  },
+  officePictures{
+    images[]{
+      "imageUrl": asset->url
+    }
+  },
+  commitments{
+    items[]{
+      title,
+      description,
+      "iconUrl": icon.asset->url
+    }
+  },
+  coreValues{
+    values[]{
+      title,
+      description,
+      "iconUrl": icon.asset->url
     }
   }
 }`

--- a/src/sanity/schemaTypes/aboutPage.js
+++ b/src/sanity/schemaTypes/aboutPage.js
@@ -21,7 +21,7 @@ export default {
         {
             name: 'commitments',
             type: 'commitments',
-            title: 'Cam kết'
+            title: '5 không'
         },
         {
             name: 'coreValues',

--- a/src/sanity/schemaTypes/aboutPage.js
+++ b/src/sanity/schemaTypes/aboutPage.js
@@ -12,6 +12,21 @@ export default {
             name: 'teamSection',
             type: 'teamSection',
             title: 'Đội ngũ'
+        },
+        {
+            name: 'officePictures',
+            type: 'officePictures',
+            title: 'Hình ảnh văn phòng'
+        },
+        {
+            name: 'commitments',
+            type: 'commitments',
+            title: 'Cam kết'
+        },
+        {
+            name: 'coreValues',
+            type: 'coreValues',
+            title: 'Giá trị cốt lõi'
         }
     ],
     preview: {

--- a/src/sanity/schemaTypes/commitments.js
+++ b/src/sanity/schemaTypes/commitments.js
@@ -1,6 +1,6 @@
 export default {
     name: 'commitments',
-    title: 'Cam kết',
+    title: '5 không',
     type: 'object',
     fields: [
         {

--- a/src/sanity/schemaTypes/commitments.js
+++ b/src/sanity/schemaTypes/commitments.js
@@ -1,0 +1,22 @@
+export default {
+    name: 'commitments',
+    title: 'Cam kết',
+    type: 'object',
+    fields: [
+        {
+            name: 'items',
+            title: 'Danh sách cam kết',
+            type: 'array',
+            of: [
+                {
+                    type: 'object',
+                    fields: [
+                        { name: 'title', title: 'Tiêu đề', type: 'string' },
+                        { name: 'description', title: 'Mô tả', type: 'text' },
+                        { name: 'icon', title: 'Biểu tượng', type: 'image' },
+                    ]
+                }
+            ]
+        }
+    ]
+};

--- a/src/sanity/schemaTypes/coreValues.js
+++ b/src/sanity/schemaTypes/coreValues.js
@@ -1,0 +1,22 @@
+export default {
+    name: 'coreValues',
+    title: 'Giá trị cốt lõi',
+    type: 'object',
+    fields: [
+        {
+            name: 'values',
+            title: 'Danh sách giá trị',
+            type: 'array',
+            of: [
+                {
+                    type: 'object',
+                    fields: [
+                        { name: 'title', title: 'Tiêu đề', type: 'string' },
+                        { name: 'description', title: 'Mô tả', type: 'text' },
+                        { name: 'icon', title: 'Biểu tượng', type: 'image' },
+                    ]
+                }
+            ]
+        }
+    ]
+};

--- a/src/sanity/schemaTypes/footerSettings.js
+++ b/src/sanity/schemaTypes/footerSettings.js
@@ -40,24 +40,10 @@ export default {
             ],
         },
         {
-            name: 'otherBranches',
-            title: 'Chi nhánh khác',
+            name: 'footerQuotes',
+            title: 'Trích dẫn footer',
             type: 'array',
-            of: [
-                {
-                    type: 'object',
-                    fields: [
-                        { name: 'city', title: 'Thành phố', type: 'string' },
-                        { name: 'address', title: 'Địa chỉ', type: 'string' },
-                        {
-                            name: 'phones',
-                            title: 'Số điện thoại',
-                            type: 'array',
-                            of: [{ type: 'string' }],
-                        },
-                    ],
-                },
-            ],
+            of: [{ type: 'text' }],
         },
     ],
 };

--- a/src/sanity/schemaTypes/index.js
+++ b/src/sanity/schemaTypes/index.js
@@ -14,6 +14,9 @@ import service from "@/sanity/schemaTypes/service";
 import servicesPage from "@/sanity/schemaTypes/servicesPage";
 import aboutHeroSection from "@/sanity/schemaTypes/aboutHeroSection";
 import teamSection from "@/sanity/schemaTypes/teamSection";
+import commitments from "@/sanity/schemaTypes/commitments";
+import officePictures from "@/sanity/schemaTypes/officePictures";
+import coreValues from "@/sanity/schemaTypes/coreValues";
 
 import projectDetail from "@/sanity/schemaTypes/projectDetail";
 import siteSettings from "@/sanity/schemaTypes/siteSettings";
@@ -39,6 +42,9 @@ export const schemas = {
         service,
         aboutHeroSection,
         teamSection,
+        commitments,
+        officePictures,
+        coreValues,
         footerSettings,
         siteSettings,
     ],

--- a/src/sanity/schemaTypes/officePictures.js
+++ b/src/sanity/schemaTypes/officePictures.js
@@ -1,0 +1,13 @@
+export default {
+    name: 'officePictures',
+    title: 'Hình ảnh văn phòng',
+    type: 'object',
+    fields: [
+        {
+            name: 'images',
+            title: 'Danh sách hình ảnh',
+            type: 'array',
+            of: [{ type: 'image' }]
+        }
+    ]
+};


### PR DESCRIPTION
## Summary
- replace footer branch info with Sanity-driven footer quotes
- add Sanity schemas for OfficePictures, Commitments and CoreValues and wire about page

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a200fc7a488333bf67f6d76410ab08