### PR TITLE
feat: use block editor for project and news

### DIFF
--- a/sanity.config.js
+++ b/sanity.config.js
@@ -7,6 +7,7 @@
 import {visionTool} from '@sanity/vision'
 import {defineConfig} from 'sanity'
 import {structureTool} from 'sanity/structure'
+import {table} from '@sanity/table'
 
 // Go to https://www.sanity.io/docs/api-versioning to learn how API versioning works
 import {apiVersion, dataset, projectId} from '@/sanity/env'
@@ -17,11 +18,12 @@ export default defineConfig({
   projectId,
   dataset,
   // Add and edit the content schema in the './sanity/schemaTypes' folder
-  schema: schemas,
-  plugins: [
-    structureTool({structure}),
-    // Vision is for querying with GROQ from inside the Studio
-    // https://www.sanity.io/docs/the-vision-plugin
-    visionTool({defaultApiVersion: apiVersion}),
-  ],
-})
+    schema: schemas,
+    plugins: [
+      structureTool({structure}),
+      // Vision is for querying with GROQ from inside the Studio
+      // https://www.sanity.io/docs/the-vision-plugin
+      visionTool({defaultApiVersion: apiVersion}),
+      table(),
+    ],
+  })

--- a/src/sanity/lib/queries.js
+++ b/src/sanity/lib/queries.js
@@ -118,15 +118,7 @@ export const projectBySlugQuery = `*[_type == "projectDetail" && slug.current ==
     "url": asset->url,
     alt
   },
-  description,
-  sections[]{
-    content,
-    image{
-      "url": asset->url,
-      alt
-    },
-    imageSubtitle
-  }
+  body
 }`;
 
 export const projectsQuery = `*[_type == "projectDetail" && isCompleted != true]{
@@ -172,16 +164,10 @@ export const newsSlugsQuery = `*[_type == "news" && defined(slug.current)]{
 export const newsBySlugQuery = `*[_type == "news" && slug.current == $slug][0]{
   title,
   category,
+  excerpt,
   _createdAt,
   "slug": slug.current,
-  sections[]{
-    header,
-    content,
-    images[]{
-      "url": asset->url,
-      alt
-    }
-  }
+  body
 }`;
 
 export const newsQuery = `*[_type == "news"] | order(_createdAt desc){

--- a/src/sanity/schemaTypes/blockContent.js
+++ b/src/sanity/schemaTypes/blockContent.js
@@ -1,0 +1,52 @@
+export default {
+  title: 'Block Content',
+  name: 'blockContent',
+  type: 'array',
+  of: [
+    {
+      title: 'Block',
+      type: 'block',
+      styles: [
+        { title: 'Normal', value: 'normal' },
+        { title: 'Heading 1', value: 'h1' },
+        { title: 'Heading 2', value: 'h2' },
+        { title: 'Heading 3', value: 'h3' },
+        { title: 'Quote', value: 'blockquote' },
+      ],
+      lists: [
+        { title: 'Bullet', value: 'bullet' },
+        { title: 'Numbered', value: 'number' },
+      ],
+      marks: {
+        decorators: [
+          { title: 'Strong', value: 'strong' },
+          { title: 'Emphasis', value: 'em' },
+          { title: 'Code', value: 'code' },
+        ],
+        annotations: [
+          {
+            name: 'link',
+            type: 'object',
+            title: 'Link',
+            fields: [
+              { name: 'href', type: 'url', title: 'Url' },
+            ],
+          },
+        ],
+      },
+    },
+    { type: 'table' },
+    {
+      type: 'image',
+      options: { hotspot: true },
+      fields: [
+        {
+          name: 'alt',
+          type: 'string',
+          title: 'Alt text',
+          description: 'Alternative text for the image',
+        },
+      ],
+    },
+  ],
+}

--- a/src/sanity/schemaTypes/index.js
+++ b/src/sanity/schemaTypes/index.js
@@ -21,6 +21,7 @@ import coreValues from "@/sanity/schemaTypes/coreValues";
 import projectDetail from "@/sanity/schemaTypes/projectDetail";
 import siteSettings from "@/sanity/schemaTypes/siteSettings";
 import news from "@/sanity/schemaTypes/news";
+import blockContent from "@/sanity/schemaTypes/blockContent";
 
 
 export const schemas = {
@@ -34,6 +35,7 @@ export const schemas = {
         constructionVideo,
         project,
         projectDetail,
+        blockContent,
         news,
         partner,
         testimonial,

--- a/src/sanity/schemaTypes/news.js
+++ b/src/sanity/schemaTypes/news.js
@@ -70,37 +70,9 @@ export default {
             type: 'text',
         },
         {
-            name: 'sections',
-            title: 'Các phần',
-            type: 'array',
-            of: [
-                {
-                    type: 'object',
-                    fields: [
-                        { name: 'header', title: 'Tiêu đề phần', type: 'string' },
-                        { name: 'content', title: 'Nội dung', type: 'text' },
-                        {
-                            name: 'images',
-                            title: 'Hình ảnh',
-                            type: 'array',
-                            of: [
-                                {
-                                    type: 'image',
-                                    options: { hotspot: true },
-                                    fields: [
-                                        {
-                                            name: 'alt',
-                                            title: 'Alt',
-                                            type: 'string',
-                                            description: 'Tự động tạo từ tiêu đề nếu bỏ trống',
-                                        },
-                                    ],
-                                },
-                            ],
-                        },
-                    ],
-                },
-            ],
+            name: 'body',
+            title: 'Nội dung',
+            type: 'blockContent',
         },
     ],
 };

--- a/src/sanity/schemaTypes/projectDetail.js
+++ b/src/sanity/schemaTypes/projectDetail.js
@@ -76,37 +76,9 @@ export default {
             ]
         },
         {
-            name: 'description',
-            title: 'Mô tả',
-            type: 'text'
-        },
-        {
-            name: 'sections',
-            title: 'Các phần',
-            type: 'array',
-            of: [
-                {
-                    type: 'object',
-                    fields: [
-                        { name: 'content', title: 'Nội dung', type: 'text' },
-                        {
-                            name: 'image',
-                            title: 'Hình ảnh',
-                            type: 'image',
-                            options: { hotspot: true },
-                            fields: [
-                                {
-                                    name: 'alt',
-                                    title: 'Alt',
-                                    type: 'string',
-                                    description: 'Tự động tạo từ tiêu đề nếu bỏ trống'
-                                }
-                            ]
-                        },
-                        { name: 'imageSubtitle', title: 'Chú thích ảnh', type: 'string' }
-                    ]
-                }
-            ]
+            name: 'body',
+            title: 'Nội dung',
+            type: 'blockContent'
         }
     ]
 };


### PR DESCRIPTION
## Summary
- add Sanity table plugin and blockContent support for tables
- enhance news and project pages with PortableText headings and SEO metadata
- refactor project schema and queries to store rich text body

## Testing
- `npm run lint`
- `npm install @sanity/table@latest` (fails: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68a2ac3f17b48333b107548920298071