### PR TITLE
feat: enable sanity visual editing

### DIFF
--- a/sanity.config.js
+++ b/sanity.config.js
@@ -8,6 +8,7 @@ import {visionTool} from '@sanity/vision'
 import {defineConfig} from 'sanity'
 import {structureTool} from 'sanity/structure'
 import {table} from '@sanity/table'
+import {presentationTool} from 'next-sanity'
 
 // Go to https://www.sanity.io/docs/api-versioning to learn how API versioning works
 import {apiVersion, dataset, projectId} from '@/sanity/env'
@@ -25,5 +26,13 @@ export default defineConfig({
       // https://www.sanity.io/docs/the-vision-plugin
       visionTool({defaultApiVersion: apiVersion}),
       table(),
+      presentationTool({
+        previewUrl: {
+          origin: process.env.NEXT_PUBLIC_SITE_URL,
+          previewMode: {
+            enable: '/api/draft-mode/enable',
+          },
+        },
+      }),
     ],
   })

--- a/src/app/api/draft-mode/enable/route.js
+++ b/src/app/api/draft-mode/enable/route.js
@@ -1,0 +1,7 @@
+import {client} from '@/sanity/lib/client'
+import {token} from '@/sanity/lib/token'
+import {defineEnableDraftMode} from 'next-sanity/draft-mode'
+
+export const {GET} = defineEnableDraftMode({
+  client: client.withConfig({token}),
+})

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -2,6 +2,9 @@
 import "./globals.css";
 import {mulish} from "@/app/fonts";
 import {Toaster} from "react-hot-toast";
+import {draftMode} from 'next/headers'
+import {VisualEditing} from 'next-sanity'
+import {SanityLive} from '@/sanity/lib/live'
 
 
 export const metadata = {
@@ -11,12 +14,15 @@ export const metadata = {
     twitter: { card: "summary_large_image" }
 };
 
-export default function RootLayout({children}) {
+export default async function RootLayout({children}) {
+    const {isEnabled} = await draftMode()
     return (
         <html lang="en" suppressHydrationWarning className={`${mulish.className} antialiased`}>
         <body suppressHydrationWarning>
         {children}
         <Toaster/>
+        <SanityLive/>
+        {isEnabled && <VisualEditing/>}
         </body>
         </html>
     );

--- a/src/sanity/lib/client.js
+++ b/src/sanity/lib/client.js
@@ -1,10 +1,12 @@
-import { createClient } from 'next-sanity'
+import {createClient} from 'next-sanity'
 
-import { apiVersion, dataset, projectId } from '../env'
+import {apiVersion, dataset, projectId} from '../env'
 
 export const client = createClient({
   projectId,
   dataset,
   apiVersion,
-  useCdn: true, // Set to false if statically generating pages, using ISR or tag-based revalidation
+  // Set to false if statically generating pages, using ISR or tag-based revalidation
+  useCdn: true,
+  stega: {studioUrl: '/admin'},
 })

--- a/src/sanity/lib/live.js
+++ b/src/sanity/lib/live.js
@@ -1,13 +1,12 @@
 // Querying with "sanityFetch" will keep content automatically updated
 // Before using it, import and render "<SanityLive />" in your layout, see
 // https://github.com/sanity-io/next-sanity#live-content-api for more information.
-import { defineLive } from "next-sanity";
-import { client } from './client'
+import {defineLive} from 'next-sanity'
+import {client} from './client'
+import {token} from './token'
 
-export const { sanityFetch, SanityLive } = defineLive({ 
-  client: client.withConfig({ 
-    // Live content is currently only available on the experimental API
-    // https://www.sanity.io/docs/api-versioning
-    apiVersion: 'vX' 
-  }) 
-});
+export const {sanityFetch, SanityLive} = defineLive({
+  client,
+  serverToken: token,
+  browserToken: token,
+})

--- a/src/sanity/lib/token.js
+++ b/src/sanity/lib/token.js
@@ -1,0 +1,5 @@
+export const token = process.env.SANITY_API_READ_TOKEN;
+
+if (!token) {
+  throw new Error('Missing SANITY_API_READ_TOKEN');
+}


### PR DESCRIPTION
## Summary
- integrate Sanity Presentation Tool for preview and draft mode support
- expose read token and live client for Visual Editing
- render live preview and Visual Editing components in root layout

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3fb8008a48333b51de8f6e661b3ba