### PR TITLE
feat: load floating button links from site settings

### DIFF
--- a/src/app/(site)/layout.js
+++ b/src/app/(site)/layout.js
@@ -1,30 +1,21 @@
-'use client';
-import {usePathname} from 'next/navigation';
 import Navbar from "../../components/Navbar";
 import Footer from "../../components/Footer";
 import FloatingButtons from "../../components/FloatingButtons";
 import {client} from "@/sanity/lib/client";
-import {footerQuery} from "@/sanity/lib/queries";
+import {footerQuery, siteSettingsQuery} from "@/sanity/lib/queries";
 import ContactForm from "@/components/ContactForm";
-import {useEffect, useState} from 'react';
 
-export default function SiteLayout({children}) {
-    const pathname = usePathname();
-    const [footerData, setFooterData] = useState(null);
-
-    useEffect(() => {
-        const fetchFooterData = async () => {
-            const data = await client.fetch(footerQuery);
-            setFooterData(data);
-        };
-        fetchFooterData();
-    }, []);
+export default async function SiteLayout({children}) {
+    const [footerData, siteSettings] = await Promise.all([
+        client.fetch(footerQuery),
+        client.fetch(siteSettingsQuery),
+    ]);
 
     return (
         <>
             <Navbar/>
             {children}
-            <FloatingButtons/>
+            <FloatingButtons settings={siteSettings}/>
             <div className="py-30">
                 <ContactForm/>
             </div>

--- a/src/components/FloatingButtons.js
+++ b/src/components/FloatingButtons.js
@@ -6,38 +6,7 @@ import * as Tooltip from "@radix-ui/react-tooltip";
 import {TooltipProvider} from "@radix-ui/react-tooltip";
 import ContactPopover from "@/components/ContactPopover";
 
-const socialLinks = [
-    {
-        id: "messenger",
-        href: "https://m.me/",
-        img: <Image src="/images/Messenger_Icon_Primary_Blue.png" alt="Messenger" width={24} height={24}/>,
-        alt: "Nhắn tin với chúng tôi qua Facebook",
-        external: true,
-    },
-    {
-        id: "zalo",
-        href: "https://zalo.me/",
-        img: <Image src="/images/Icon_of_Zalo.svg" alt="Zalo" width={24} height={24}/>,
-        alt: "Liên hệ với chúng tôi qua Zalo",
-        external: true,
-    },
-    {
-        id: "phone",
-        href: "tel:0123456789",
-        img: <lucide.Phone size={24} className="text-white"/>,
-        alt: "Liên hệ với chúng tôi qua điện thoại",
-        external: false,
-    },
-    {
-        id: "contact",
-        href: "#",
-        img: <lucide.Send size={24} className="text-white"/>,
-        alt: "Xin quý khách để lại thông tin, chúng tôi sẽ liên hệ lại",
-        external: false,
-    }
-];
-
-function FloatingButtons() {
+function FloatingButtons({settings}) {
     const [collapsed, setCollapsed] = useState(false);
     const [isOverflow, setIsOverflow] = useState(false);
     const listRef = React.useRef(null);
@@ -68,6 +37,37 @@ function FloatingButtons() {
             setIsOverflow(rect.height > window.innerHeight - 32);
         }
     }, [collapsed]);
+
+    const socialLinks = [
+        ...(settings?.facebook ? [{
+            id: "messenger",
+            href: settings.facebook,
+            img: <Image src="/images/Messenger_Icon_Primary_Blue.png" alt="Messenger" width={24} height={24}/>,
+            alt: "Nhắn tin với chúng tôi qua Messenger",
+            external: true,
+        }] : []),
+        ...(settings?.zalo ? [{
+            id: "zalo",
+            href: settings.zalo,
+            img: <Image src="/images/Icon_of_Zalo.svg" alt="Zalo" width={24} height={24}/>,
+            alt: "Liên hệ với chúng tôi qua Zalo",
+            external: true,
+        }] : []),
+        ...(settings?.phoneNumber ? [{
+            id: "phone",
+            href: `tel:${settings.phoneNumber}`,
+            img: <lucide.Phone size={24} className="text-white"/>,
+            alt: "Liên hệ với chúng tôi qua điện thoại",
+            external: false,
+        }] : []),
+        {
+            id: "contact",
+            href: "#",
+            img: <lucide.Send size={24} className="text-white"/>,
+            alt: "Xin quý khách để lại thông tin, chúng tôi sẽ liên hệ lại",
+            external: false,
+        }
+    ];
 
     return (
         <TooltipProvider delayDuration={0}>

--- a/src/sanity/lib/queries.js
+++ b/src/sanity/lib/queries.js
@@ -160,7 +160,8 @@ export const siteSettingsQuery = `*[_type == "siteSettings"][0]{
   robots,
   facebook,
   zalo,
-  youtube
+  youtube,
+  phoneNumber
 }`;
 
 export const newsSlugsQuery = `*[_type == "news" && defined(slug.current)]{

--- a/src/sanity/schemaTypes/siteSettings.js
+++ b/src/sanity/schemaTypes/siteSettings.js
@@ -19,5 +19,7 @@ export default {
         { name: 'facebook', title: 'Facebook', type: 'url' },
         { name: 'zalo', title: 'Zalo', type: 'url' },
         { name: 'youtube', title: 'Youtube', type: 'url' },
+        // thông tin liên hệ
+        { name: 'phoneNumber', title: 'Số điện thoại', type: 'string' },
     ]
 }


### PR DESCRIPTION
## Summary
- fetch messenger, zalo, and phone links from global site settings
- expose phoneNumber in site settings schema and query
- load site settings in layout and pass to FloatingButtons to keep fetching on the server
- parallelize layout's footer and settings fetches

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a442ebc16083338f018d9413aa0b4c