### PR TITLE
refactor project categories to separate document

### DIFF
--- a/src/app/(site)/completed-projects/page.js
+++ b/src/app/(site)/completed-projects/page.js
@@ -1,19 +1,22 @@
 import {sanityFetch} from "@/sanity/lib/live";
-import { completedProjectsQuery, bannerQuery } from "@/sanity/lib/queries";
+import { completedProjectsQuery, bannerQuery, projectCategoriesQuery } from "@/sanity/lib/queries";
 import Banner from "@/components/ui/banner";
 import ProjectsFilter from "@/components/ProjectsFilter";
 
 export default async function CompletedProject({ searchParams }) {
     const { category } = await searchParams;
-    const {data: projects} = await sanityFetch({query: completedProjectsQuery});
-    const {data: banner} = await sanityFetch({query: bannerQuery});
+    const [{data: projects}, {data: banner}, {data: categories}] = await Promise.all([
+        sanityFetch({query: completedProjectsQuery}),
+        sanityFetch({query: bannerQuery}),
+        sanityFetch({query: projectCategoriesQuery})
+    ]);
     const useDefault = banner?.completedUseDefault !== false;
     const images = (useDefault ? banner?.defaultSlides : banner?.completedSlides) || [];
     return (
         <div className="min-h-screen bg-[#272727] text-center">
             <Banner title="Thi công thực tế" images={images} />
             <div className="container mx-auto px-4 sm:px-6 md:px-10 pb-20 md:pb-30">
-                <ProjectsFilter projects={projects} initialCategory={category || 'all'} />
+                <ProjectsFilter projects={projects} categories={categories} initialCategory={category || 'all'} />
             </div>
         </div>
     );

--- a/src/app/(site)/projects/[slug]/page.js
+++ b/src/app/(site)/projects/[slug]/page.js
@@ -43,15 +43,8 @@ export default async function ProjectDetailPage({params}) {
     }
     const {data: contactData} = await sanityFetch({query: contactFormQuery});
 
-    const {title, shortDescription, information, gallery, body, category, _createdAt, _updatedAt, _type, mainImage, slug: projectSlug} = project;
+    const {title, shortDescription, information, gallery, body, category, categoryTitle, _createdAt, _updatedAt, _type, mainImage, slug: projectSlug} = project;
     const isCompleted = _type === 'completedProject';
-    const categoryLabels = {
-        mansion: 'Biệt thự',
-        urbanHouse: 'Nhà phố',
-        countryHouse: 'Nhà vườn',
-        neoClassicHouse: 'Nhà tân cổ điển',
-        serviceBuilding: 'Công trình dịch vụ',
-    };
 
     const baseUrl = (process.env.NEXT_PUBLIC_SITE_URL || '').replace(/\/$/, '');
     const imageUrl = mainImage ? urlFor(mainImage).width(1200).height(630).url() : undefined;
@@ -83,7 +76,7 @@ export default async function ProjectDetailPage({params}) {
                                 href={`${isCompleted ? '/completed-projects' : '/projects'}?category=${category}`}
                                 className="hover:underline"
                             >
-                                {categoryLabels[category] || category}
+                                {categoryTitle || category}
                             </Link>
                         </>
                     )}

--- a/src/app/(site)/projects/page.js
+++ b/src/app/(site)/projects/page.js
@@ -1,19 +1,22 @@
 import {sanityFetch} from "@/sanity/lib/live";
-import {projectsQuery, bannerQuery} from "@/sanity/lib/queries";
+import {projectsQuery, bannerQuery, projectCategoriesQuery} from "@/sanity/lib/queries";
 import Banner from "@/components/ui/banner";
 import ProjectsFilter from "@/components/ProjectsFilter";
 
 export default async function ProjectsPage({ searchParams }) {
     const { category } = await searchParams;
-    const {data: projects} = await sanityFetch({query: projectsQuery});
-    const {data: banner} = await sanityFetch({query: bannerQuery});
+    const [{data: projects}, {data: banner}, {data: categories}] = await Promise.all([
+        sanityFetch({query: projectsQuery}),
+        sanityFetch({query: bannerQuery}),
+        sanityFetch({query: projectCategoriesQuery})
+    ]);
     const useDefault = banner?.projectsUseDefault !== false;
     const images = (useDefault ? banner?.defaultSlides : banner?.projectsSlides) || [];
     return (
         <div className="min-h-screen bg-[#272727] text-center">
             <Banner title="Dự án" images={images} />
             <div className="container mx-auto px-4 sm:px-6 md:px-10 pb-20 md:pb-30">
-                <ProjectsFilter projects={projects} initialCategory={category || 'all'} />
+                <ProjectsFilter projects={projects} categories={categories} initialCategory={category || 'all'} />
             </div>
         </div>
     );

--- a/src/components/ProjectsFilter.js
+++ b/src/components/ProjectsFilter.js
@@ -7,18 +7,10 @@ import CategoryTags from './CategoryTags';
 import Pagination from './Pagination';
 import {SearchX} from "lucide-react";
 
-const categories = [
-    { value: 'all', title: 'Tất cả' },
-    { value: 'mansion', title: 'Biệt thự' },
-    { value: 'urbanHouse', title: 'Nhà phố' },
-    { value: 'countryHouse', title: 'Nhà vườn' },
-    { value: 'neoClassicHouse', title: 'Nhà tân cổ điển' },
-    { value: 'serviceBuilding', title: 'Công trình dịch vụ' }
-];
-
 const ITEMS_PER_PAGE = 12;
 
-export default function ProjectsFilter({ projects, initialCategory = 'all' }) {
+export default function ProjectsFilter({ projects, categories = [], initialCategory = 'all' }) {
+    const allCategories = [{ value: 'all', title: 'Tất cả' }, ...categories];
     const [filteredProjects, setFilteredProjects] = useState(projects);
     const [selectedCategory, setSelectedCategory] = useState(initialCategory);
     const [searchTerm, setSearchTerm] = useState('');
@@ -94,7 +86,7 @@ export default function ProjectsFilter({ projects, initialCategory = 'all' }) {
 
                 {/* Category Tags */}
                 <CategoryTags
-                    categories={categories}
+                    categories={allCategories}
                     selectedCategory={selectedCategory}
                     onCategoryChange={handleCategoryChange}
                 />
@@ -108,7 +100,7 @@ export default function ProjectsFilter({ projects, initialCategory = 'all' }) {
                                 <span> cho "{searchTerm}"</span>
                             )}
                             {selectedCategory !== 'all' && (
-                                <span> trong danh mục "{categories.find(cat => cat.value === selectedCategory)?.title}"</span>
+                                <span> trong danh mục "{allCategories.find(cat => cat.value === selectedCategory)?.title}"</span>
                             )}
             </span>
                     ) : (

--- a/src/components/ProjectsGrid.js
+++ b/src/components/ProjectsGrid.js
@@ -1,6 +1,5 @@
 import Image from 'next/image';
 import Link from 'next/link';
-import {getCategoryTitle} from "@/lib/utils";
 import {MoveUpRight} from "lucide-react";
 
 export default function ProjectsGrid({projects = []}) {

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -4,15 +4,3 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs) {
   return twMerge(clsx(inputs));
 }
-export const getCategoryTitle = (categoryValue) => {
-  const categoryMap = {
-    'mansion': 'Biệt thự',
-    'urbanHouse': 'Nhà phố',
-    'countryHouse': 'Nhà vườn',
-    'neoClassicHouse': 'Nhà tân cổ điển',
-    'serviceBuilding': 'Công trình dịch vụ',
-    'generalNews': 'Tin tức chung',
-    'activities': 'Hoạt động công ty'
-  };
-  return categoryMap[categoryValue] || categoryValue;
-};

--- a/src/sanity/lib/queries.js
+++ b/src/sanity/lib/queries.js
@@ -112,7 +112,8 @@ export const projectBySlugQuery = `*[_type in ["projectDetail", "completedProjec
   title,
   shortDescription,
   information,
-  category,
+  "category": category->slug.current,
+  "categoryTitle": category->title,
   _createdAt,
   _updatedAt,
   "slug": slug.current,
@@ -135,7 +136,8 @@ export const projectsQuery = `*[_type == "projectDetail"] | order(_createdAt des
   "constructionArea": information.constructionArea,
   "location": information.location,
   "function": information.function,
-  category,
+  "category": category->slug.current,
+  "categoryTitle": category->title,
   _createdAt
 }`;
 
@@ -149,8 +151,14 @@ export const completedProjectsQuery = `*[_type == "completedProject"] | order(_c
   "constructionArea": information.constructionArea,
   "location": information.location,
   "function": information.function,
-  category,
+  "category": category->slug.current,
+  "categoryTitle": category->title,
   _createdAt
+}`;
+
+export const projectCategoriesQuery = `*[_type == "projectCategory"] | order(title asc){
+  title,
+  "value": slug.current
 }`;
 
 export const siteSettingsQuery = `*[_type == "siteSettings"][0]{

--- a/src/sanity/schemaTypes/index.js
+++ b/src/sanity/schemaTypes/index.js
@@ -25,6 +25,7 @@ import news from "@/sanity/schemaTypes/news";
 import blockContent from "@/sanity/schemaTypes/blockContent";
 import seo from "@/sanity/schemaTypes/seo";
 import siteBanner from "@/sanity/schemaTypes/siteBanner";
+import projectCategory from "@/sanity/schemaTypes/projectCategory";
 
 
 export const schemas = {
@@ -39,6 +40,7 @@ export const schemas = {
         project,
         projectDetail,
         completedProject,
+        projectCategory,
         blockContent,
         news,
         partner,

--- a/src/sanity/schemaTypes/projectCategory.js
+++ b/src/sanity/schemaTypes/projectCategory.js
@@ -1,0 +1,23 @@
+export default {
+    name: 'projectCategory',
+    title: 'Danh mục dự án',
+    type: 'document',
+    fields: [
+        {
+            name: 'title',
+            title: 'Tiêu đề',
+            type: 'string',
+            validation: Rule => Rule.required()
+        },
+        {
+            name: 'slug',
+            title: 'Slug',
+            type: 'slug',
+            options: {
+                source: 'title',
+                maxLength: 96
+            },
+            validation: Rule => Rule.required()
+        }
+    ]
+};

--- a/src/sanity/schemaTypes/projectDetail.js
+++ b/src/sanity/schemaTypes/projectDetail.js
@@ -34,16 +34,8 @@ export const projectDetailFields = [
     {
         name: 'category',
         title: 'Danh mục',
-        type: 'string',
-        options: {
-            list: [
-                { title: 'Biệt thự', value: 'mansion' },
-                { title: 'Nhà phố', value: 'urbanHouse' },
-                { title: 'Nhà vườn', value: 'countryHouse' },
-                { title: 'Nhà tân cổ điển', value: 'neoClassicHouse' },
-                { title: 'Công trình dịch vụ', value: 'serviceBuilding' },
-            ],
-        },
+        type: 'reference',
+        to: [{ type: 'projectCategory' }],
         validation: Rule => Rule.required()
     },
     {


### PR DESCRIPTION
## Summary
- add `projectCategory` schema and reference it from project details
- load project categories from Sanity for project listings
- show category titles from referenced documents

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7f91ed4588333b96461e7d27466bd