### PR TITLE
refactor: replace amber accents with orange-400

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -30,6 +30,7 @@
     --color-destructive: var(--destructive);
     --color-accent-foreground: var(--accent-foreground);
     --color-accent: var(--accent);
+    --color-accent-light: var(--accent-light);
     --color-muted-foreground: var(--muted-foreground);
     --color-muted: var(--muted);
     --color-secondary-foreground: var(--secondary-foreground);
@@ -60,7 +61,8 @@
     --secondary-foreground: oklch(0.205 0 0);
     --muted: oklch(0.97 0 0);
     --muted-foreground: oklch(0.556 0 0);
-    --accent: oklch(0.97 0 0);
+    --accent: #f97316;
+    --accent-light: #fb923c;
     --accent-foreground: oklch(0.205 0 0);
     --destructive: oklch(0.577 0.245 27.325);
     --border: oklch(0.922 0 0);
@@ -94,7 +96,8 @@
     --secondary-foreground: oklch(0.985 0 0);
     --muted: oklch(0.269 0 0);
     --muted-foreground: oklch(0.708 0 0);
-    --accent: oklch(0.269 0 0);
+    --accent: #f97316;
+    --accent-light: #fb923c;
     --accent-foreground: oklch(0.985 0 0);
     --destructive: oklch(0.704 0.191 22.216);
     --border: oklch(1 0 0 / 10%);

--- a/src/components/CategoryTags.js
+++ b/src/components/CategoryTags.js
@@ -9,7 +9,7 @@ export default function CategoryTags({ categories, selectedCategory, onCategoryC
                     onClick={() => onCategoryChange(category.value)}
                     className={`px-4 py-2 rounded-full text-sm font-medium transition-all duration-200 ${
                         selectedCategory === category.value
-                            ? 'bg-orange-400 text-black'
+                            ? 'bg-[var(--accent-light)] text-black'
                             : 'bg-gray-700 text-gray-300 hover:bg-gray-600 hover:text-white'
                     }`}
                 >

--- a/src/components/CategoryTags.js
+++ b/src/components/CategoryTags.js
@@ -9,7 +9,7 @@ export default function CategoryTags({ categories, selectedCategory, onCategoryC
                     onClick={() => onCategoryChange(category.value)}
                     className={`px-4 py-2 rounded-full text-sm font-medium transition-all duration-200 ${
                         selectedCategory === category.value
-                            ? 'bg-amber-400 text-black'
+                            ? 'bg-orange-400 text-black'
                             : 'bg-gray-700 text-gray-300 hover:bg-gray-600 hover:text-white'
                     }`}
                 >

--- a/src/components/NewsFilter.js
+++ b/src/components/NewsFilter.js
@@ -114,7 +114,7 @@ export default function NewsFilter({ news }) {
                     <h3 className="text-xl font-semibold text-gray-300 mb-6">Không tìm thấy bài viết nào</h3>
                     <button
                         onClick={resetFilters}
-                        className="px-6 py-2 bg-amber-400 text-white rounded-lg hover:bg-amber-500 transition-colors"
+                        className="px-6 py-2 bg-orange-400 text-white rounded-lg hover:bg-orange-500 transition-colors"
                     >
                         Xóa tất cả bộ lọc
                     </button>

--- a/src/components/NewsFilter.js
+++ b/src/components/NewsFilter.js
@@ -114,7 +114,7 @@ export default function NewsFilter({ news }) {
                     <h3 className="text-xl font-semibold text-gray-300 mb-6">Không tìm thấy bài viết nào</h3>
                     <button
                         onClick={resetFilters}
-                        className="px-6 py-2 bg-orange-400 text-white rounded-lg hover:bg-orange-500 transition-colors"
+                        className="px-6 py-2 bg-[var(--accent-light)] text-white rounded-lg hover:bg-[var(--accent)] transition-colors"
                     >
                         Xóa tất cả bộ lọc
                     </button>

--- a/src/components/Pagination.js
+++ b/src/components/Pagination.js
@@ -70,7 +70,7 @@ export default function Pagination({ currentPage, totalPages, onPageChange }) {
                             onClick={() => onPageChange(page)}
                             className={`px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
                                 currentPage === page
-                                    ? 'bg-amber-400 text-black'
+                                    ? 'bg-orange-400 text-black'
                                     : 'bg-gray-700 text-gray-300 hover:bg-gray-600 hover:text-white'
                             }`}
                         >

--- a/src/components/Pagination.js
+++ b/src/components/Pagination.js
@@ -70,7 +70,7 @@ export default function Pagination({ currentPage, totalPages, onPageChange }) {
                             onClick={() => onPageChange(page)}
                             className={`px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
                                 currentPage === page
-                                    ? 'bg-orange-400 text-black'
+                                    ? 'bg-[var(--accent-light)] text-black'
                                     : 'bg-gray-700 text-gray-300 hover:bg-gray-600 hover:text-white'
                             }`}
                         >

--- a/src/components/ProjectsFilter.js
+++ b/src/components/ProjectsFilter.js
@@ -142,7 +142,7 @@ export default function ProjectsFilter({ projects, initialCategory = 'all' }) {
                     <h3 className="text-xl font-semibold text-gray-300 mb-6">Không tìm thấy dự án nào</h3>
                     <button
                         onClick={resetFilters}
-                        className="px-6 py-2 bg-orange-400 text-white rounded-lg hover:bg-orange-500 transition-colors"
+                        className="px-6 py-2 bg-[var(--accent-light)] text-white rounded-lg hover:bg-[var(--accent)] transition-colors"
                     >
                         Xóa tất cả bộ lọc
                     </button>

--- a/src/components/ProjectsFilter.js
+++ b/src/components/ProjectsFilter.js
@@ -142,7 +142,7 @@ export default function ProjectsFilter({ projects, initialCategory = 'all' }) {
                     <h3 className="text-xl font-semibold text-gray-300 mb-6">Không tìm thấy dự án nào</h3>
                     <button
                         onClick={resetFilters}
-                        className="px-6 py-2 bg-amber-400 text-white rounded-lg hover:bg-amber-500 transition-colors"
+                        className="px-6 py-2 bg-orange-400 text-white rounded-lg hover:bg-orange-500 transition-colors"
                     >
                         Xóa tất cả bộ lọc
                     </button>

--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -21,7 +21,7 @@ export default function SearchBar({ searchTerm, onSearchChange, placeholder = 'T
                 placeholder={placeholder}
                 value={searchTerm}
                 onChange={handleChange}
-                className="block w-full pl-10 pr-10 py-3 border border-gray-600 rounded-lg bg-gray-800 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-orange-400 focus:border-transparent"
+                className="block w-full pl-10 pr-10 py-3 border border-gray-600 rounded-lg bg-gray-800 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-[var(--accent-light)] focus:border-transparent"
             />
             {searchTerm && (
                 <button

--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -21,7 +21,7 @@ export default function SearchBar({ searchTerm, onSearchChange, placeholder = 'T
                 placeholder={placeholder}
                 value={searchTerm}
                 onChange={handleChange}
-                className="block w-full pl-10 pr-10 py-3 border border-gray-600 rounded-lg bg-gray-800 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-amber-400 focus:border-transparent"
+                className="block w-full pl-10 pr-10 py-3 border border-gray-600 rounded-lg bg-gray-800 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-orange-400 focus:border-transparent"
             />
             {searchTerm && (
                 <button


### PR DESCRIPTION
## Summary
- swap amber highlight classes for orange-400 across UI filters and pagination
- align search bar focus ring with new orange accent

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c12fe17df88333a8b171efdb6c26b6