### PR TITLE
fix: wire project detail route params

### DIFF
--- a/src/app/(site)/completed-projects/[slug]/page.js
+++ b/src/app/(site)/completed-projects/[slug]/page.js
@@ -1,7 +1,10 @@
-import ProjectDetailPage from "@/app/(site)/projects/[slug]/page";
+import ProjectDetailPage, {
+  generateMetadata,
+  generateStaticParams,
+} from "@/components/ProjectDetailPage"
 
-export default function CompletedProjects() {
-    return (
-        <ProjectDetailPage/>
-    )
+export { generateMetadata, generateStaticParams }
+
+export default function CompletedProjectsPage({ params }) {
+  return <ProjectDetailPage params={params} />
 }

--- a/src/app/(site)/projects/[slug]/page.js
+++ b/src/app/(site)/projects/[slug]/page.js
@@ -1,7 +1,10 @@
-import ProjectDetailPage from "@/components/ProjectDetailPage";
+import ProjectDetailPage, {
+  generateMetadata,
+  generateStaticParams,
+} from "@/components/ProjectDetailPage"
 
-export default function ProjectsPage() {
-    return (
-        <ProjectDetailPage/>
-    )
+export { generateMetadata, generateStaticParams }
+
+export default function ProjectsPage({ params }) {
+  return <ProjectDetailPage params={params} />
 }


### PR DESCRIPTION
## Summary
- forward dynamic route params to the shared project detail page implementation
- re-export metadata/static params helpers from both project detail routes so they participate in SSG

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbc6d91bcc83338742f927267ec5ec