### PR TITLE
Add created date fields to projects and news

### DIFF
--- a/src/app/(site)/news/[slug]/page.js
+++ b/src/app/(site)/news/[slug]/page.js
@@ -42,7 +42,9 @@ export default async function NewsDetailPage({ params }) {
     const {data: contactData} = await sanityFetch({query: contactFormQuery});
     const {data: siteSettings} = await sanityFetch({query: siteSettingsQuery});
 
-    const { title, body, category, _createdAt, _updatedAt, thumbnail } = news;
+    const { title, body, category, createdDate, _createdAt, _updatedAt, thumbnail } = news;
+    const publishedDate = createdDate || _createdAt;
+    const updatedDate = _updatedAt || publishedDate;
     const categoryLabels = {
         generalNews: 'Tin tức chung',
         activities: 'Hoạt động công ty',
@@ -53,8 +55,8 @@ export default async function NewsDetailPage({ params }) {
         '@context': 'https://schema.org',
         '@type': 'NewsArticle',
         headline: title,
-        datePublished: _createdAt,
-        dateModified: _updatedAt || _createdAt,
+        datePublished: publishedDate,
+        dateModified: updatedDate,
         image: thumbnail ? [urlFor(thumbnail).width(1200).height(630).url()] : undefined,
         mainEntityOfPage: `${baseUrl}/news/${news.slug}`
     };
@@ -95,7 +97,7 @@ export default async function NewsDetailPage({ params }) {
                                     <Youtube className="w-5 h-5" />
                                 </a>
                             )}
-                            <span className="text-sm text-gray-400">{new Date(_createdAt).toLocaleDateString('vi-VN')}</span>
+                            <span className="text-sm text-gray-400">{new Date(publishedDate).toLocaleDateString('vi-VN')}</span>
                         </div>
                           {body && (
                               <PortableText

--- a/src/components/ProjectDetailPage.js
+++ b/src/components/ProjectDetailPage.js
@@ -60,6 +60,7 @@ export default async function ProjectDetailPage({ params }) {
         gallery,
         body,
         category,
+        createdDate,
         _createdAt,
         _updatedAt,
         _type,
@@ -70,6 +71,8 @@ export default async function ProjectDetailPage({ params }) {
     const isCompleted = _type === 'completedProject'
     const segment = isCompleted ? 'completed-projects' : 'projects'
     const slugStr = getSlug(projectSlug) || slug
+    const publishedDate = createdDate || _createdAt
+    const updatedDate = _updatedAt || publishedDate
 
     const categoryLabels = {
         mansion: 'Biệt thự',
@@ -86,8 +89,8 @@ export default async function ProjectDetailPage({ params }) {
         '@context': 'https://schema.org',
         '@type': 'Article',
         headline: title,
-        datePublished: _createdAt,
-        dateModified: _updatedAt || _createdAt,
+        datePublished: publishedDate,
+        dateModified: updatedDate,
         image: imageUrl ? [imageUrl] : undefined,
         mainEntityOfPage: `${baseUrl}/${segment}/${slugStr}`,
     }

--- a/src/sanity/lib/queries.js
+++ b/src/sanity/lib/queries.js
@@ -113,6 +113,7 @@ export const projectBySlugQuery = `*[_type in ["projectDetail", "completedProjec
     function
   },
   category,
+  "createdDate": coalesce(createdDate, _createdAt),
   _createdAt,
   _updatedAt,
   "slug": slug.current,
@@ -126,7 +127,7 @@ export const projectBySlugQuery = `*[_type in ["projectDetail", "completedProjec
 }`;
 
 
-export const projectsQuery = `*[_type == "projectDetail"] | order(_createdAt desc){
+export const projectsQuery = `*[_type == "projectDetail"] | order(coalesce(createdDate, _createdAt) desc){
   _id,
   title,
   shortDescription,
@@ -137,10 +138,11 @@ export const projectsQuery = `*[_type == "projectDetail"] | order(_createdAt des
   "location": information.location,
   "function": information.function,
   category,
+  "createdDate": coalesce(createdDate, _createdAt),
   _createdAt
 }`;
 
-export const completedProjectsQuery = `*[_type == "completedProject"] | order(_createdAt desc){
+export const completedProjectsQuery = `*[_type == "completedProject"] | order(coalesce(createdDate, _createdAt) desc){
   _id,
   title,
   shortDescription,
@@ -151,6 +153,7 @@ export const completedProjectsQuery = `*[_type == "completedProject"] | order(_c
   "location": information.location,
   "function": information.function,
   category,
+  "createdDate": coalesce(createdDate, _createdAt),
   _createdAt
 }`;
 
@@ -177,13 +180,14 @@ export const newsBySlugQuery = `*[_type == "news" && slug.current == $slug][0]{
   thumbnail,
   "mainImage": thumbnail,
   seo,
+  "createdDate": coalesce(createdDate, _createdAt),
   _createdAt,
   _updatedAt,
   "slug": slug.current,
   body
 }`;
 
-export const newsQuery = `*[_type == "news"] | order(_createdAt desc){
+export const newsQuery = `*[_type == "news"] | order(coalesce(createdDate, _createdAt) desc){
   _id,
   title,
   "slug": slug.current,
@@ -197,6 +201,7 @@ export const newsQuery = `*[_type == "news"] | order(_createdAt desc){
     ""
   ),
   category,
+  "createdDate": coalesce(createdDate, _createdAt),
   _createdAt
 }`;
 

--- a/src/sanity/schemaTypes/news.js
+++ b/src/sanity/schemaTypes/news.js
@@ -84,6 +84,17 @@ export default {
             validation: Rule => Rule.required(),
         },
         {
+            name: 'createdDate',
+            title: 'Ngày tạo',
+            type: 'datetime',
+            options: {
+                dateFormat: 'DD/MM/YY',
+                timeFormat: 'HH:mm:ss',
+                timeStep: 1,
+            },
+            initialValue: () => new Date().toISOString(),
+        },
+        {
             name: 'thumbnail',
             title: 'Thumbnail',
             type: 'image',

--- a/src/sanity/schemaTypes/projectDetail.js
+++ b/src/sanity/schemaTypes/projectDetail.js
@@ -66,6 +66,17 @@ export const projectDetailFields = [
             })
     },
     {
+        name: 'createdDate',
+        title: 'Ngày tạo',
+        type: 'datetime',
+        options: {
+            dateFormat: 'DD/MM/YY',
+            timeFormat: 'HH:mm:ss',
+            timeStep: 1
+        },
+        initialValue: () => new Date().toISOString()
+    },
+    {
         name: 'category',
         title: 'Danh mục',
         type: 'string',


### PR DESCRIPTION
## Summary
- add a `createdDate` datetime field to project detail/completed project and news schemas with defaults
- sort project, completed project, and news queries by the new created date while exposing the value to clients
- use the surfaced created date for project and news detail metadata and published timestamps

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbd027d058833398765b97fb4723be