### PR TITLE
Refactor homepage sections for mobile responsiveness

### DIFF
--- a/src/components/ProcessTabs.js
+++ b/src/components/ProcessTabs.js
@@ -101,11 +101,11 @@ export default function ProcessTabs({ data }) {
   return (
     <section>
       {/* ✅ Tabs Header */}
-      <div className="container mx-auto flex justify-center bg-white">
+      <div className="container mx-auto flex flex-col items-center gap-2 bg-white px-4 sm:flex-row sm:justify-center">
         {tabs.map((tab) => (
           <button
             key={tab.id}
-            className={`text-xl w-sm px-4 py-2 ${
+            className={`text-base sm:text-lg w-full sm:w-auto px-4 py-2 transition-colors ${
               activeTab === tab.id
                 ? 'bg-orange-400 text-white'
                 : 'bg-black text-white'
@@ -120,32 +120,33 @@ export default function ProcessTabs({ data }) {
       {/* ✅ Tabs Content */}
       <div className="bg-black py-12 px-4">
         <div className="max-w-6xl mx-auto px-4">
-          <div className="container mx-auto flex justify-between items-center px-4 space-x-8">
+          <div className="container mx-auto grid grid-cols-2 gap-6 sm:gap-8 md:flex md:justify-between md:items-start md:space-x-8 md:px-4">
             {tabs
               .find((tab) => tab.id === activeTab)
               ?.steps.map((step, index, arr) => (
                 <div
                   key={index}
-                  className="flex items-start w-1/4 h-64 text-ellipsis"
+                  className="flex flex-col items-center text-center gap-3 md:flex md:flex-row md:items-start md:text-left md:w-1/4 md:gap-4"
                 >
-                  <div>
-                    <div className="w-32 h-32 mx-auto mb-2">
-                      <Image
-                        src={step.iconSrc}
-                        alt={step.alt}
-                        width={150}
-                        height={150}
-                      />
-                    </div>
-                    <h3 className="text-orange-400 text-lg text-center font-semibold mb-2">
+                  <div className="w-24 h-24 sm:w-28 sm:h-28 md:w-32 md:h-32 mx-auto md:mx-0">
+                    <Image
+                      src={step.iconSrc}
+                      alt={step.alt}
+                      width={150}
+                      height={150}
+                      className="h-full w-full object-contain"
+                    />
+                  </div>
+                  <div className="flex flex-col items-center text-center gap-2 md:items-start md:text-left">
+                    <h3 className="text-orange-400 text-sm sm:text-base md:text-lg font-semibold">
                       {step.title}
                     </h3>
-                    <p className="text-sm text-gray-300 text-center">
+                    <p className="text-xs sm:text-sm text-gray-300">
                       {step.description}
                     </p>
                   </div>
                   {index < arr.length - 1 && (
-                    <div className="w-16 flex justify-center self-center">
+                    <div className="hidden md:flex w-16 justify-center self-center">
                       <ArrowRight className="text-gray-300" size={40} />
                     </div>
                   )}

--- a/src/components/Testimonial.js
+++ b/src/components/Testimonial.js
@@ -56,15 +56,16 @@ function AvatarImage({avatar, alt}) {
 function TestimonialCard({testimonial}) {
     return (
         <div className="grid grid-cols-1 place-content-center">
-            <div className="flex flex-col bg-white p-6 h-60 max-h-60 overflow-hidden">
-                <Quote className="mb-2 text-center text-5xl text-orange-500 flex-shrink-0"/>
+            <div className="flex flex-col bg-white p-6 md:h-60 md:max-h-60 overflow-hidden">
+                <Quote className="mb-2 hidden text-center text-5xl text-orange-500 flex-shrink-0 sm:flex"/>
                 <blockquote
-                    className="mb-2 whitespace-pre-line text-center text-base font-normal italic text-black flex-1 overflow-hidden">
+                    className="mb-2 whitespace-pre-line text-center text-sm font-normal italic text-black flex-1 overflow-hidden line-clamp-6 md:text-base md:line-clamp-none">
                     {testimonial.quote}
                 </blockquote>
-                <Quote className="mb-6 self-end text-5xl text-orange-500 flex-shrink-0"/>
+                <Quote className="mb-6 hidden self-end text-5xl text-orange-500 flex-shrink-0 sm:flex"/>
                 {testimonial?.link && (
-                    <a href={testimonial.link} className="self-end text-orange-400 underline flex-shrink-0">
+                    <a href={testimonial.link}
+                       className="self-end text-sm text-orange-400 underline flex-shrink-0 md:text-base">
                         Tham quan nhà hoàn thiện
                     </a>
                 )}

--- a/src/components/WhyChooseUs.js
+++ b/src/components/WhyChooseUs.js
@@ -60,32 +60,32 @@ const WhyChooseUs = () => {
                     <Image src="/images/logo.png" alt="logo" width={250} height={200} className="w-[120px] md:w-[250px] h-auto"/>
                 </div>
                 {/* Counter 1 - Top position */}
-                <div className="absolute -top-4 -right-24 md:-top-6 md:-right-36 flex items-center space-x-3 md:space-x-6">
+                <div className="absolute -top-4 -right-24 md:-top-6 md:-right-36 flex items-center space-x-2 md:space-x-6">
                     <div className="relative w-4 h-4 rounded-full bg-orange-400 ping"/>
-                    <div className="text-2xl md:text-3xl font-bold text-orange-500 counter-trigger">
+                    <div className="text-lg md:text-3xl font-bold text-orange-500 counter-trigger">
                         {counter1.toLocaleString()}+
-                        <div className="text-xs md:text-sm text-gray-600 uppercase tracking-wide">
+                        <div className="text-[10px] md:text-sm text-gray-600 uppercase tracking-wide">
                             NĂM KINH NGHIỆM
                         </div>
                     </div>
                 </div>
                 {/* Counter 2 - Middle position */}
-                <div className="absolute -right-28 md:-right-57 flex items-center space-x-3 md:space-x-5">
+                <div className="absolute -right-28 md:-right-57 flex items-center space-x-2 md:space-x-5">
                     <div className="relative w-4 h-4 rounded-full bg-orange-400 ping"/>
-                    <div className="text-2xl md:text-3xl font-bold text-orange-500 counter-trigger">
-                        <div className="mb-2">{counter2.toLocaleString()}+</div>
-                        <div className="text-xs md:text-sm text-gray-600 uppercase tracking-wide">
+                    <div className="text-lg md:text-3xl font-bold text-orange-500 counter-trigger">
+                        <div className="mb-1 md:mb-2">{counter2.toLocaleString()}+</div>
+                        <div className="text-[10px] md:text-sm text-gray-600 uppercase tracking-wide">
                             MẪU THIẾT KẾ HIỆN ĐẠI
                         </div>
                     </div>
                 </div>
 
                 {/* Counter 3 - Bottom  position */}
-                <div className="absolute -bottom-4 -right-32 md:-bottom-6 md:-right-48 flex items-center space-x-3 md:space-x-5">
+                <div className="absolute -bottom-4 -right-32 md:-bottom-6 md:-right-48 flex items-center space-x-2 md:space-x-5">
                     <div className="relative w-4 h-4 rounded-full bg-orange-400 ping"/>
-                    <div className="text-2xl md:text-3xl font-bold text-orange-500 counter-trigger">
+                    <div className="text-lg md:text-3xl font-bold text-orange-500 counter-trigger">
                         {counter3.toLocaleString()}+
-                        <div className="text-xs md:text-sm text-gray-600 uppercase tracking-wide">
+                        <div className="text-[10px] md:text-sm text-gray-600 uppercase tracking-wide">
                             KHÁCH HÀNG THÂN THIẾT
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- shrink counter typography in WhyChooseUs to avoid clipping on handheld screens
- reorganize ProcessTabs content into a responsive grid while keeping desktop arrows
- adjust testimonial card spacing, typography, and quote graphics for mobile readability

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68dba50c58248333b1136766203b322c