### PR TITLE
fix: improve image quality for news post content images

### DIFF
--- a/src/app/(site)/news/[slug]/page.js
+++ b/src/app/(site)/news/[slug]/page.js
@@ -111,10 +111,10 @@ export default async function NewsDetailPage({ params }) {
                                       types: {
                                           image: ({ value }) => (
                                               <Image
-                                                  src={urlFor(value).width(800).url()}
+                                                  src={urlFor(value).width(1600).auto('format').quality(90).url()}
                                                   alt={value.alt || title}
-                                                  width={800}
-                                                  height={600}
+                                                  width={1600}
+                                                  height={1200}
                                                   className="w-full h-auto my-4"
                                               />
                                           ),


### PR DESCRIPTION
### Motivation
- Images embedded in news article bodies were being requested from Sanity at `width(800)`, causing compression/blurriness on larger displays.

### Description
- Updated the PortableText `image` serializer in `src/app/(site)/news/[slug]/page.js` to request higher-resolution assets with `urlFor(value).width(1600).auto('format').quality(90).url()` and adjusted the intrinsic `width`/`height` passed to `next/image` accordingly.

### Testing
- Ran `npm run lint` which completed successfully (existing unrelated lint warnings remain).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e59a207cf883339fac61e48a790168)