### PR TITLE
Add zoomable PortableText image component and use it in news detail page

### DIFF
--- a/src/app/(site)/news/[slug]/page.js
+++ b/src/app/(site)/news/[slug]/page.js
@@ -8,6 +8,7 @@ import { newsBySlugQuery, newsSlugsQuery, contactFormQuery, siteSettingsQuery } 
 import { mapSeoToMetadata } from '@/app/lib/seo';
 import ContactForm from '@/components/ContactForm';
 import { Facebook, Youtube, Share2 } from 'lucide-react';
+import PortableTextZoomImage from '@/components/PortableTextZoomImage';
 
 export async function generateStaticParams() {
     const {data: slugs} = await sanityFetch({
@@ -110,13 +111,7 @@ export default async function NewsDetailPage({ params }) {
                                       },
                                       types: {
                                           image: ({ value }) => (
-                                              <Image
-                                                  src={urlFor(value).width(800).url()}
-                                                  alt={value.alt || title}
-                                                  width={800}
-                                                  height={600}
-                                                  className="w-full h-auto my-4"
-                                              />
+                                              <PortableTextZoomImage value={value} fallbackAlt={title} />
                                           ),
                                       },
                                   }}

--- a/src/components/PortableTextZoomImage.js
+++ b/src/components/PortableTextZoomImage.js
@@ -1,0 +1,71 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import Image from 'next/image';
+import FullscreenModal from '@/components/FullscreenModal';
+import { urlFor } from '@/sanity/lib/image';
+
+function getSanityImageDimensions(image) {
+  const ref = image?.asset?._ref;
+  if (!ref) return { width: 1600, height: 900 };
+
+  const parts = ref.split('-');
+  const dimensions = parts[2] || '';
+  const [width, height] = dimensions.split('x').map(Number);
+
+  if (!Number.isFinite(width) || !Number.isFinite(height)) {
+    return { width: 1600, height: 900 };
+  }
+
+  return { width, height };
+}
+
+export default function PortableTextZoomImage({ value, fallbackAlt }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const { width, height } = useMemo(() => getSanityImageDimensions(value), [value]);
+
+  const inlineUrl = useMemo(
+    () => urlFor(value).fit('max').auto('format').quality(100).url(),
+    [value]
+  );
+
+  const fullSizeUrl = useMemo(() => urlFor(value).url(), [value]);
+
+  const images = useMemo(
+    () => [
+      {
+        url: fullSizeUrl,
+        alt: value?.alt || fallbackAlt || 'image',
+      },
+    ],
+    [fallbackAlt, fullSizeUrl, value?.alt]
+  );
+
+  return (
+    <>
+      <button
+        type="button"
+        className="w-full my-4 block cursor-zoom-in"
+        onClick={() => setIsOpen(true)}
+        aria-label="Open full size image"
+      >
+        <Image
+          src={inlineUrl}
+          alt={value?.alt || fallbackAlt || 'image'}
+          width={width}
+          height={height}
+          className="w-full h-auto"
+        />
+      </button>
+
+      <FullscreenModal
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        images={images}
+        currentIndex={0}
+        showControls={false}
+        showCounter={false}
+      />
+    </>
+  );
+}


### PR DESCRIPTION
### Motivation
- Enable inline images in rich PortableText content to be opened in a fullscreen zoom/lightbox for better viewing on article pages.
- Preserve Sanity image aspect ratios and use optimized inline and full-size image URLs generated via `urlFor` while keeping client-side modal behavior separated from server-rendered page code.

### Description
- Introduce a new client component `PortableTextZoomImage` that extracts dimensions from a Sanity image ref, builds an optimized inline URL and a full-size URL with `urlFor`, and opens a `FullscreenModal` when clicked.
- Replace the inline image renderer in the news article page `src/app/(site)/news/[slug]/page.js` PortableText `types.image` implementation to render `PortableTextZoomImage` with a `fallbackAlt` prop.
- Add an import for `PortableTextZoomImage` in the news detail page and update the image rendering to delegate zoom and modal concerns to the new component.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e59a207cf883339fac61e48a790168)