### PR TITLE
Use PortableTextZoomImage for portable text images in ProjectDetailPage

### DIFF
--- a/src/components/ProjectDetailPage.js
+++ b/src/components/ProjectDetailPage.js
@@ -15,6 +15,7 @@ import ContactForm from '@/components/ContactForm'
 import ProjectGallery from '@/components/ProjectGallery'
 import { Facebook, Share2 } from 'lucide-react'
 import ProjectInformation from '@/components/ProjectInformation'
+import PortableTextZoomImage from '@/components/PortableTextZoomImage'
 
 // helpers
 const getSlug = (v) =>
@@ -141,13 +142,7 @@ export default async function ProjectDetailPage({ params }) {
                                             },
                                             types: {
                                                 image: ({ value }) => (
-                                                    <Image
-                                                        src={urlFor(value).width(800).url()}
-                                                        alt={value.alt || title}
-                                                        width={800}
-                                                        height={600}
-                                                        className="w-full h-auto my-4"
-                                                    />
+                                                    <PortableTextZoomImage value={value} fallbackAlt={title} />
                                                 ),
                                             },
                                         }}


### PR DESCRIPTION
### Motivation
- Replace direct `next/image` rendering inside portable text with a dedicated `PortableTextZoomImage` component to provide zoom behavior and consistent alt handling for project body content.

### Description
- Import `PortableTextZoomImage` and update the `PortableText` `types.image` renderer in `ProjectDetailPage.js` to use `<PortableTextZoomImage value={value} fallbackAlt={title} />` instead of an inline `Image` component.

### Testing
- Ran `npm run lint`, `npm test`, and a `next build` verification locally and all automated checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5a905612483339fd9d17570039fc1)