### PR TITLE
feat: add center alignment support for Portable Text

### DIFF
--- a/src/app/(site)/news/[slug]/page.js
+++ b/src/app/(site)/news/[slug]/page.js
@@ -10,6 +10,11 @@ import ContactForm from '@/components/ContactForm';
 import { Facebook, Youtube, Share2 } from 'lucide-react';
 import PortableTextZoomImage from '@/components/PortableTextZoomImage';
 
+const getTextAlignClass = (textAlign) => {
+    if (textAlign === 'center') return 'text-center';
+    return 'text-left';
+};
+
 export async function generateStaticParams() {
     const {data: slugs} = await sanityFetch({
         query: newsSlugsQuery,
@@ -105,9 +110,12 @@ export default async function NewsDetailPage({ params }) {
                                   value={body}
                                   components={{
                                       block: {
-                                          h1: ({ children }) => <h1 className="text-3xl font-bold my-4">{children}</h1>,
-                                          h2: ({ children }) => <h2 className="text-2xl font-semibold my-3">{children}</h2>,
-                                          h3: ({ children }) => <h3 className="text-xl font-semibold my-2">{children}</h3>,
+                                          normal: ({ children, value }) => (
+                                              <p className={getTextAlignClass(value?.textAlign)}>{children}</p>
+                                          ),
+                                          h1: ({ children, value }) => <h1 className={`text-3xl font-bold my-4 ${getTextAlignClass(value?.textAlign)}`}>{children}</h1>,
+                                          h2: ({ children, value }) => <h2 className={`text-2xl font-semibold my-3 ${getTextAlignClass(value?.textAlign)}`}>{children}</h2>,
+                                          h3: ({ children, value }) => <h3 className={`text-xl font-semibold my-2 ${getTextAlignClass(value?.textAlign)}`}>{children}</h3>,
                                       },
                                       types: {
                                           image: ({ value }) => (

--- a/src/app/(site)/news/[slug]/page.js
+++ b/src/app/(site)/news/[slug]/page.js
@@ -12,6 +12,8 @@ import PortableTextZoomImage from '@/components/PortableTextZoomImage';
 
 const getTextAlignClass = (textAlign) => {
     if (textAlign === 'center') return 'text-center';
+    if (textAlign === 'right') return 'text-right';
+    if (textAlign === 'justify') return 'text-justify';
     return 'text-left';
 };
 

--- a/src/components/ProjectDetailPage.js
+++ b/src/components/ProjectDetailPage.js
@@ -19,6 +19,8 @@ import PortableTextZoomImage from '@/components/PortableTextZoomImage'
 
 const getTextAlignClass = (textAlign) => {
     if (textAlign === 'center') return 'text-center'
+    if (textAlign === 'right') return 'text-right'
+    if (textAlign === 'justify') return 'text-justify'
     return 'text-left'
 }
 

--- a/src/components/ProjectDetailPage.js
+++ b/src/components/ProjectDetailPage.js
@@ -17,6 +17,11 @@ import { Facebook, Share2 } from 'lucide-react'
 import ProjectInformation from '@/components/ProjectInformation'
 import PortableTextZoomImage from '@/components/PortableTextZoomImage'
 
+const getTextAlignClass = (textAlign) => {
+    if (textAlign === 'center') return 'text-center'
+    return 'text-left'
+}
+
 // helpers
 const getSlug = (v) =>
     typeof v === 'string' ? v : Array.isArray(v) ? v[0] : v && v.current
@@ -136,9 +141,18 @@ export default async function ProjectDetailPage({ params }) {
                                         value={body}
                                         components={{
                                             block: {
-                                                h1: ({ children }) => <h1 className="text-3xl font-bold my-4">{children}</h1>,
-                                                h2: ({ children }) => <h2 className="text-2xl font-semibold my-3">{children}</h2>,
-                                                h3: ({ children }) => <h3 className="text-xl font-semibold my-2">{children}</h3>,
+                                                normal: ({ children, value }) => (
+                                                    <p className={getTextAlignClass(value?.textAlign)}>{children}</p>
+                                                ),
+                                                h1: ({ children, value }) => (
+                                                    <h1 className={`text-3xl font-bold my-4 ${getTextAlignClass(value?.textAlign)}`}>{children}</h1>
+                                                ),
+                                                h2: ({ children, value }) => (
+                                                    <h2 className={`text-2xl font-semibold my-3 ${getTextAlignClass(value?.textAlign)}`}>{children}</h2>
+                                                ),
+                                                h3: ({ children, value }) => (
+                                                    <h3 className={`text-xl font-semibold my-2 ${getTextAlignClass(value?.textAlign)}`}>{children}</h3>
+                                                ),
                                             },
                                             types: {
                                                 image: ({ value }) => (

--- a/src/sanity/schemaTypes/blockContent.js
+++ b/src/sanity/schemaTypes/blockContent.js
@@ -6,6 +6,22 @@ export default {
     {
       title: 'Block',
       type: 'block',
+      fields: [
+        {
+          name: 'textAlign',
+          title: 'Text Align',
+          type: 'string',
+          initialValue: 'left',
+          options: {
+            list: [
+              { title: 'Left', value: 'left' },
+              { title: 'Center', value: 'center' },
+            ],
+            layout: 'radio',
+            direction: 'horizontal',
+          },
+        },
+      ],
       styles: [
         { title: 'Normal', value: 'normal' },
         { title: 'Heading 1', value: 'h1' },

--- a/src/sanity/schemaTypes/blockContent.js
+++ b/src/sanity/schemaTypes/blockContent.js
@@ -16,6 +16,8 @@ export default {
             list: [
               { title: 'Left', value: 'left' },
               { title: 'Center', value: 'center' },
+              { title: 'Right', value: 'right' },
+              { title: 'Justify', value: 'justify' },
             ],
             layout: 'radio',
             direction: 'horizontal',


### PR DESCRIPTION
### Motivation
- Allow content editors to set per-block text alignment (center/left) in Portable Text so posts can have centered headings and paragraphs without custom HTML.

### Description
- Added a `textAlign` block field to the Sanity Portable Text schema in `src/sanity/schemaTypes/blockContent.js` with `left` and `center` options and a horizontal radio UI. 
- Added a `getTextAlignClass` helper and updated Portable Text renderers in `src/components/ProjectDetailPage.js` to apply `text-left`/`text-center` for `normal`, `h1`, `h2`, and `h3` blocks using `value?.textAlign`.
- Applied the same renderer changes to the news detail page at `src/app/(site)/news/[slug]/page.js` so news articles respect the block alignment selection.

### Testing
- Ran `npm run lint`, which completed successfully; the project still reports pre-existing lint warnings unrelated to this change. 
- No new unit/integration tests were added as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13c9d1f32c83339cdf79ac8bfb54db)