### PR TITLE
fix: allow Sanity CDN images to render in posts

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -10,6 +10,12 @@ const nextConfig = {
         port: '',
         pathname: '/**',
       },
+      {
+        protocol: 'https',
+        hostname: 'cdn.sanity.io',
+        port: '',
+        pathname: '/**',
+      },
     ],
   },
 };


### PR DESCRIPTION
### Motivation
- A news post's images were missing because Next.js `images.remotePatterns` only allowlisted `nhadepquangnam.vn`, preventing images served from the Sanity CDN from loading.

### Description
- Added `cdn.sanity.io` to `images.remotePatterns` in `next.config.mjs` so Next.js `Image` can load Sanity-hosted assets used by news thumbnails and body images.

### Testing
- Ran `npm run -s lint` which completed successfully (only unrelated warnings were reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13ca1e78b88333b59f2daacc2dcd32)