### PR TITLE
Switch Sanity block alignment to style variants and update PortableText renderer

### DIFF
--- a/src/components/ProjectDetailPage.js
+++ b/src/components/ProjectDetailPage.js
@@ -17,10 +17,10 @@ import { Facebook, Share2 } from 'lucide-react'
 import ProjectInformation from '@/components/ProjectInformation'
 import PortableTextZoomImage from '@/components/PortableTextZoomImage'
 
-const getTextAlignClass = (textAlign) => {
-    if (textAlign === 'center') return 'text-center'
-    if (textAlign === 'right') return 'text-right'
-    if (textAlign === 'justify') return 'text-justify'
+const getTextAlignClassFromStyle = (style) => {
+    if (style?.endsWith('Center')) return 'text-center'
+    if (style?.endsWith('Right')) return 'text-right'
+    if (style?.endsWith('Justify')) return 'text-justify'
     return 'text-left'
 }
 
@@ -144,16 +144,52 @@ export default async function ProjectDetailPage({ params }) {
                                         components={{
                                             block: {
                                                 normal: ({ children, value }) => (
-                                                    <p className={getTextAlignClass(value?.textAlign)}>{children}</p>
+                                                    <p className={getTextAlignClassFromStyle(value?.style)}>{children}</p>
+                                                ),
+                                                normalCenter: ({ children, value }) => (
+                                                    <p className={getTextAlignClassFromStyle(value?.style)}>{children}</p>
+                                                ),
+                                                normalRight: ({ children, value }) => (
+                                                    <p className={getTextAlignClassFromStyle(value?.style)}>{children}</p>
+                                                ),
+                                                normalJustify: ({ children, value }) => (
+                                                    <p className={getTextAlignClassFromStyle(value?.style)}>{children}</p>
                                                 ),
                                                 h1: ({ children, value }) => (
-                                                    <h1 className={`text-3xl font-bold my-4 ${getTextAlignClass(value?.textAlign)}`}>{children}</h1>
+                                                    <h1 className={`text-3xl font-bold my-4 ${getTextAlignClassFromStyle(value?.style)}`}>{children}</h1>
+                                                ),
+                                                h1Center: ({ children, value }) => (
+                                                    <h1 className={`text-3xl font-bold my-4 ${getTextAlignClassFromStyle(value?.style)}`}>{children}</h1>
+                                                ),
+                                                h1Right: ({ children, value }) => (
+                                                    <h1 className={`text-3xl font-bold my-4 ${getTextAlignClassFromStyle(value?.style)}`}>{children}</h1>
+                                                ),
+                                                h1Justify: ({ children, value }) => (
+                                                    <h1 className={`text-3xl font-bold my-4 ${getTextAlignClassFromStyle(value?.style)}`}>{children}</h1>
                                                 ),
                                                 h2: ({ children, value }) => (
-                                                    <h2 className={`text-2xl font-semibold my-3 ${getTextAlignClass(value?.textAlign)}`}>{children}</h2>
+                                                    <h2 className={`text-2xl font-semibold my-3 ${getTextAlignClassFromStyle(value?.style)}`}>{children}</h2>
+                                                ),
+                                                h2Center: ({ children, value }) => (
+                                                    <h2 className={`text-2xl font-semibold my-3 ${getTextAlignClassFromStyle(value?.style)}`}>{children}</h2>
+                                                ),
+                                                h2Right: ({ children, value }) => (
+                                                    <h2 className={`text-2xl font-semibold my-3 ${getTextAlignClassFromStyle(value?.style)}`}>{children}</h2>
+                                                ),
+                                                h2Justify: ({ children, value }) => (
+                                                    <h2 className={`text-2xl font-semibold my-3 ${getTextAlignClassFromStyle(value?.style)}`}>{children}</h2>
                                                 ),
                                                 h3: ({ children, value }) => (
-                                                    <h3 className={`text-xl font-semibold my-2 ${getTextAlignClass(value?.textAlign)}`}>{children}</h3>
+                                                    <h3 className={`text-xl font-semibold my-2 ${getTextAlignClassFromStyle(value?.style)}`}>{children}</h3>
+                                                ),
+                                                h3Center: ({ children, value }) => (
+                                                    <h3 className={`text-xl font-semibold my-2 ${getTextAlignClassFromStyle(value?.style)}`}>{children}</h3>
+                                                ),
+                                                h3Right: ({ children, value }) => (
+                                                    <h3 className={`text-xl font-semibold my-2 ${getTextAlignClassFromStyle(value?.style)}`}>{children}</h3>
+                                                ),
+                                                h3Justify: ({ children, value }) => (
+                                                    <h3 className={`text-xl font-semibold my-2 ${getTextAlignClassFromStyle(value?.style)}`}>{children}</h3>
                                                 ),
                                             },
                                             types: {

--- a/src/sanity/schemaTypes/blockContent.js
+++ b/src/sanity/schemaTypes/blockContent.js
@@ -6,29 +6,23 @@ export default {
     {
       title: 'Block',
       type: 'block',
-      fields: [
-        {
-          name: 'textAlign',
-          title: 'Text Align',
-          type: 'string',
-          initialValue: 'left',
-          options: {
-            list: [
-              { title: 'Left', value: 'left' },
-              { title: 'Center', value: 'center' },
-              { title: 'Right', value: 'right' },
-              { title: 'Justify', value: 'justify' },
-            ],
-            layout: 'radio',
-            direction: 'horizontal',
-          },
-        },
-      ],
       styles: [
         { title: 'Normal', value: 'normal' },
+        { title: 'Normal (Center)', value: 'normalCenter' },
+        { title: 'Normal (Right)', value: 'normalRight' },
+        { title: 'Normal (Justify)', value: 'normalJustify' },
         { title: 'Heading 1', value: 'h1' },
+        { title: 'Heading 1 (Center)', value: 'h1Center' },
+        { title: 'Heading 1 (Right)', value: 'h1Right' },
+        { title: 'Heading 1 (Justify)', value: 'h1Justify' },
         { title: 'Heading 2', value: 'h2' },
+        { title: 'Heading 2 (Center)', value: 'h2Center' },
+        { title: 'Heading 2 (Right)', value: 'h2Right' },
+        { title: 'Heading 2 (Justify)', value: 'h2Justify' },
         { title: 'Heading 3', value: 'h3' },
+        { title: 'Heading 3 (Center)', value: 'h3Center' },
+        { title: 'Heading 3 (Right)', value: 'h3Right' },
+        { title: 'Heading 3 (Justify)', value: 'h3Justify' },
         { title: 'Quote', value: 'blockquote' },
       ],
       lists: [


### PR DESCRIPTION
### Motivation

- Move text alignment from a block-level `textAlign` field to explicit style variants to better match Sanity Portable Text conventions and editor UX.
- Update the front-end renderer to read alignment from block `style` values instead of a custom field so alignment stays in sync with the schema.

### Description

- Removed the custom `textAlign` field from the `block` schema in `src/sanity/schemaTypes/blockContent.js` and added style variants for alignment such as `normalCenter`, `normalRight`, `normalJustify`, and equivalent variants for `h1`, `h2`, and `h3`.
- Replaced `getTextAlignClass` with `getTextAlignClassFromStyle` in `src/components/ProjectDetailPage.js` to derive alignment classes from `value?.style` (matching the new style suffixes).
- Extended the `PortableText` `block` component mapping to handle the new style values (e.g. `normalCenter`, `h1Right`, `h2Justify`, etc.) and updated headings and paragraphs to use the new helper.

### Testing

- Ran the project build with `npm run build` and the build completed successfully.
- Ran the test suite with `npm test` and all tests passed.
- Ran linting with `npm run lint` and no lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13f6792104833386a3368d253ab96b)