### PR TITLE
Simplify PortableText alignment handling and add alignment marks/blockquote support

### DIFF
--- a/src/app/(site)/news/[slug]/page.js
+++ b/src/app/(site)/news/[slug]/page.js
@@ -10,12 +10,6 @@ import ContactForm from '@/components/ContactForm';
 import { Facebook, Youtube, Share2 } from 'lucide-react';
 import PortableTextZoomImage from '@/components/PortableTextZoomImage';
 
-const getTextAlignClass = (textAlign) => {
-    if (textAlign === 'center') return 'text-center';
-    if (textAlign === 'right') return 'text-right';
-    if (textAlign === 'justify') return 'text-justify';
-    return 'text-left';
-};
 
 export async function generateStaticParams() {
     const {data: slugs} = await sanityFetch({
@@ -112,12 +106,16 @@ export default async function NewsDetailPage({ params }) {
                                   value={body}
                                   components={{
                                       block: {
-                                          normal: ({ children, value }) => (
-                                              <p className={getTextAlignClass(value?.textAlign)}>{children}</p>
-                                          ),
-                                          h1: ({ children, value }) => <h1 className={`text-3xl font-bold my-4 ${getTextAlignClass(value?.textAlign)}`}>{children}</h1>,
-                                          h2: ({ children, value }) => <h2 className={`text-2xl font-semibold my-3 ${getTextAlignClass(value?.textAlign)}`}>{children}</h2>,
-                                          h3: ({ children, value }) => <h3 className={`text-xl font-semibold my-2 ${getTextAlignClass(value?.textAlign)}`}>{children}</h3>,
+                                          normal: ({ children }) => <p>{children}</p>,
+                                          h1: ({ children }) => <h1 className="text-3xl font-bold my-4">{children}</h1>,
+                                          h2: ({ children }) => <h2 className="text-2xl font-semibold my-3">{children}</h2>,
+                                          h3: ({ children }) => <h3 className="text-xl font-semibold my-2">{children}</h3>,
+                                          blockquote: ({ children }) => <blockquote>{children}</blockquote>,
+                                      },
+                                      marks: {
+                                          left: ({ children }) => <div className="text-left w-full">{children}</div>,
+                                          center: ({ children }) => <div className="text-center w-full">{children}</div>,
+                                          right: ({ children }) => <div className="text-right w-full">{children}</div>,
                                       },
                                       types: {
                                           image: ({ value }) => (

--- a/src/components/ProjectDetailPage.js
+++ b/src/components/ProjectDetailPage.js
@@ -17,12 +17,6 @@ import { Facebook, Share2 } from 'lucide-react'
 import ProjectInformation from '@/components/ProjectInformation'
 import PortableTextZoomImage from '@/components/PortableTextZoomImage'
 
-const getTextAlignClassFromStyle = (style) => {
-    if (style?.endsWith('Center')) return 'text-center'
-    if (style?.endsWith('Right')) return 'text-right'
-    if (style?.endsWith('Justify')) return 'text-justify'
-    return 'text-left'
-}
 
 // helpers
 const getSlug = (v) =>
@@ -143,54 +137,16 @@ export default async function ProjectDetailPage({ params }) {
                                         value={body}
                                         components={{
                                             block: {
-                                                normal: ({ children, value }) => (
-                                                    <p className={getTextAlignClassFromStyle(value?.style)}>{children}</p>
-                                                ),
-                                                normalCenter: ({ children, value }) => (
-                                                    <p className={getTextAlignClassFromStyle(value?.style)}>{children}</p>
-                                                ),
-                                                normalRight: ({ children, value }) => (
-                                                    <p className={getTextAlignClassFromStyle(value?.style)}>{children}</p>
-                                                ),
-                                                normalJustify: ({ children, value }) => (
-                                                    <p className={getTextAlignClassFromStyle(value?.style)}>{children}</p>
-                                                ),
-                                                h1: ({ children, value }) => (
-                                                    <h1 className={`text-3xl font-bold my-4 ${getTextAlignClassFromStyle(value?.style)}`}>{children}</h1>
-                                                ),
-                                                h1Center: ({ children, value }) => (
-                                                    <h1 className={`text-3xl font-bold my-4 ${getTextAlignClassFromStyle(value?.style)}`}>{children}</h1>
-                                                ),
-                                                h1Right: ({ children, value }) => (
-                                                    <h1 className={`text-3xl font-bold my-4 ${getTextAlignClassFromStyle(value?.style)}`}>{children}</h1>
-                                                ),
-                                                h1Justify: ({ children, value }) => (
-                                                    <h1 className={`text-3xl font-bold my-4 ${getTextAlignClassFromStyle(value?.style)}`}>{children}</h1>
-                                                ),
-                                                h2: ({ children, value }) => (
-                                                    <h2 className={`text-2xl font-semibold my-3 ${getTextAlignClassFromStyle(value?.style)}`}>{children}</h2>
-                                                ),
-                                                h2Center: ({ children, value }) => (
-                                                    <h2 className={`text-2xl font-semibold my-3 ${getTextAlignClassFromStyle(value?.style)}`}>{children}</h2>
-                                                ),
-                                                h2Right: ({ children, value }) => (
-                                                    <h2 className={`text-2xl font-semibold my-3 ${getTextAlignClassFromStyle(value?.style)}`}>{children}</h2>
-                                                ),
-                                                h2Justify: ({ children, value }) => (
-                                                    <h2 className={`text-2xl font-semibold my-3 ${getTextAlignClassFromStyle(value?.style)}`}>{children}</h2>
-                                                ),
-                                                h3: ({ children, value }) => (
-                                                    <h3 className={`text-xl font-semibold my-2 ${getTextAlignClassFromStyle(value?.style)}`}>{children}</h3>
-                                                ),
-                                                h3Center: ({ children, value }) => (
-                                                    <h3 className={`text-xl font-semibold my-2 ${getTextAlignClassFromStyle(value?.style)}`}>{children}</h3>
-                                                ),
-                                                h3Right: ({ children, value }) => (
-                                                    <h3 className={`text-xl font-semibold my-2 ${getTextAlignClassFromStyle(value?.style)}`}>{children}</h3>
-                                                ),
-                                                h3Justify: ({ children, value }) => (
-                                                    <h3 className={`text-xl font-semibold my-2 ${getTextAlignClassFromStyle(value?.style)}`}>{children}</h3>
-                                                ),
+                                                normal: ({ children }) => <p>{children}</p>,
+                                                h1: ({ children }) => <h1 className="text-3xl font-bold my-4">{children}</h1>,
+                                                h2: ({ children }) => <h2 className="text-2xl font-semibold my-3">{children}</h2>,
+                                                h3: ({ children }) => <h3 className="text-xl font-semibold my-2">{children}</h3>,
+                                                blockquote: ({ children }) => <blockquote>{children}</blockquote>,
+                                            },
+                                            marks: {
+                                                left: ({ children }) => <div className="text-left w-full">{children}</div>,
+                                                center: ({ children }) => <div className="text-center w-full">{children}</div>,
+                                                right: ({ children }) => <div className="text-right w-full">{children}</div>,
                                             },
                                             types: {
                                                 image: ({ value }) => (

--- a/src/sanity/schemaTypes/blockContent.js
+++ b/src/sanity/schemaTypes/blockContent.js
@@ -8,21 +8,9 @@ export default {
       type: 'block',
       styles: [
         { title: 'Normal', value: 'normal' },
-        { title: 'Normal (Center)', value: 'normalCenter' },
-        { title: 'Normal (Right)', value: 'normalRight' },
-        { title: 'Normal (Justify)', value: 'normalJustify' },
         { title: 'Heading 1', value: 'h1' },
-        { title: 'Heading 1 (Center)', value: 'h1Center' },
-        { title: 'Heading 1 (Right)', value: 'h1Right' },
-        { title: 'Heading 1 (Justify)', value: 'h1Justify' },
         { title: 'Heading 2', value: 'h2' },
-        { title: 'Heading 2 (Center)', value: 'h2Center' },
-        { title: 'Heading 2 (Right)', value: 'h2Right' },
-        { title: 'Heading 2 (Justify)', value: 'h2Justify' },
         { title: 'Heading 3', value: 'h3' },
-        { title: 'Heading 3 (Center)', value: 'h3Center' },
-        { title: 'Heading 3 (Right)', value: 'h3Right' },
-        { title: 'Heading 3 (Justify)', value: 'h3Justify' },
         { title: 'Quote', value: 'blockquote' },
       ],
       lists: [
@@ -34,6 +22,9 @@ export default {
           { title: 'Strong', value: 'strong' },
           { title: 'Emphasis', value: 'em' },
           { title: 'Code', value: 'code' },
+          { title: 'Left', value: 'left' },
+          { title: 'Center', value: 'center' },
+          { title: 'Right', value: 'right' },
         ],
         annotations: [
           {


### PR DESCRIPTION
### Motivation
- Remove duplicated style-specific PortableText renderers and centralize alignment handling via marks instead of many style variants.
- Ensure blockquote rendering and add explicit inline alignment marks to give editors predictable alignment control.

### Description
- Removed custom alignment helpers `getTextAlignClass` and `getTextAlignClassFromStyle` and eliminated multiple style variants (e.g. `normalCenter`, `h1Right`) from rendering logic.
- Simplified `PortableText` `block` renderers in `News` and `Project` detail pages to use canonical `normal`, `h1`, `h2`, `h3` and `blockquote` handlers and moved alignment to `marks` handlers (`left`, `center`, `right`).
- Updated Sanity `blockContent` schema to remove many style variants and add mark decorators `left`, `center`, and `right` so alignment is represented as marks rather than distinct styles.
- Kept image rendering via `PortableTextZoomImage` and preserved existing share/social UI and metadata logic.

### Testing
- Built the Next.js app with `next build` and the build completed successfully.
- Ran linting with `npm run lint` and there were no new lint errors.
- Executed automated test suite with `npm test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14002dc4fc8333838139252b2c1d0d)