### PR TITLE
Simplify PortableText alignment and add alignment marks to Sanity schema

### DIFF
--- a/src/app/(site)/news/[slug]/page.js
+++ b/src/app/(site)/news/[slug]/page.js
@@ -10,12 +10,6 @@ import ContactForm from '@/components/ContactForm';
 import { Facebook, Youtube, Share2 } from 'lucide-react';
 import PortableTextZoomImage from '@/components/PortableTextZoomImage';
 
-const getTextAlignClass = (textAlign) => {
-    if (textAlign === 'center') return 'text-center';
-    if (textAlign === 'right') return 'text-right';
-    if (textAlign === 'justify') return 'text-justify';
-    return 'text-left';
-};
 
 export async function generateStaticParams() {
     const {data: slugs} = await sanityFetch({
@@ -112,12 +106,16 @@ export default async function NewsDetailPage({ params }) {
                                   value={body}
                                   components={{
                                       block: {
-                                          normal: ({ children, value }) => (
-                                              <p className={getTextAlignClass(value?.textAlign)}>{children}</p>
-                                          ),
-                                          h1: ({ children, value }) => <h1 className={`text-3xl font-bold my-4 ${getTextAlignClass(value?.textAlign)}`}>{children}</h1>,
-                                          h2: ({ children, value }) => <h2 className={`text-2xl font-semibold my-3 ${getTextAlignClass(value?.textAlign)}`}>{children}</h2>,
-                                          h3: ({ children, value }) => <h3 className={`text-xl font-semibold my-2 ${getTextAlignClass(value?.textAlign)}`}>{children}</h3>,
+                                          normal: ({ children }) => <p>{children}</p>,
+                                          h1: ({ children }) => <h1 className="text-3xl font-bold my-4">{children}</h1>,
+                                          h2: ({ children }) => <h2 className="text-2xl font-semibold my-3">{children}</h2>,
+                                          h3: ({ children }) => <h3 className="text-xl font-semibold my-2">{children}</h3>,
+                                          blockquote: ({ children }) => <blockquote>{children}</blockquote>,
+                                      },
+                                      marks: {
+                                          left: ({ children }) => <div className="text-left w-full">{children}</div>,
+                                          center: ({ children }) => <div className="text-center w-full">{children}</div>,
+                                          right: ({ children }) => <div className="text-right w-full">{children}</div>,
                                       },
                                       types: {
                                           image: ({ value }) => (

--- a/src/components/ProjectDetailPage.js
+++ b/src/components/ProjectDetailPage.js
@@ -17,12 +17,6 @@ import { Facebook, Share2 } from 'lucide-react'
 import ProjectInformation from '@/components/ProjectInformation'
 import PortableTextZoomImage from '@/components/PortableTextZoomImage'
 
-const getTextAlignClassFromStyle = (style) => {
-    if (style?.endsWith('Center')) return 'text-center'
-    if (style?.endsWith('Right')) return 'text-right'
-    if (style?.endsWith('Justify')) return 'text-justify'
-    return 'text-left'
-}
 
 // helpers
 const getSlug = (v) =>
@@ -143,54 +137,16 @@ export default async function ProjectDetailPage({ params }) {
                                         value={body}
                                         components={{
                                             block: {
-                                                normal: ({ children, value }) => (
-                                                    <p className={getTextAlignClassFromStyle(value?.style)}>{children}</p>
-                                                ),
-                                                normalCenter: ({ children, value }) => (
-                                                    <p className={getTextAlignClassFromStyle(value?.style)}>{children}</p>
-                                                ),
-                                                normalRight: ({ children, value }) => (
-                                                    <p className={getTextAlignClassFromStyle(value?.style)}>{children}</p>
-                                                ),
-                                                normalJustify: ({ children, value }) => (
-                                                    <p className={getTextAlignClassFromStyle(value?.style)}>{children}</p>
-                                                ),
-                                                h1: ({ children, value }) => (
-                                                    <h1 className={`text-3xl font-bold my-4 ${getTextAlignClassFromStyle(value?.style)}`}>{children}</h1>
-                                                ),
-                                                h1Center: ({ children, value }) => (
-                                                    <h1 className={`text-3xl font-bold my-4 ${getTextAlignClassFromStyle(value?.style)}`}>{children}</h1>
-                                                ),
-                                                h1Right: ({ children, value }) => (
-                                                    <h1 className={`text-3xl font-bold my-4 ${getTextAlignClassFromStyle(value?.style)}`}>{children}</h1>
-                                                ),
-                                                h1Justify: ({ children, value }) => (
-                                                    <h1 className={`text-3xl font-bold my-4 ${getTextAlignClassFromStyle(value?.style)}`}>{children}</h1>
-                                                ),
-                                                h2: ({ children, value }) => (
-                                                    <h2 className={`text-2xl font-semibold my-3 ${getTextAlignClassFromStyle(value?.style)}`}>{children}</h2>
-                                                ),
-                                                h2Center: ({ children, value }) => (
-                                                    <h2 className={`text-2xl font-semibold my-3 ${getTextAlignClassFromStyle(value?.style)}`}>{children}</h2>
-                                                ),
-                                                h2Right: ({ children, value }) => (
-                                                    <h2 className={`text-2xl font-semibold my-3 ${getTextAlignClassFromStyle(value?.style)}`}>{children}</h2>
-                                                ),
-                                                h2Justify: ({ children, value }) => (
-                                                    <h2 className={`text-2xl font-semibold my-3 ${getTextAlignClassFromStyle(value?.style)}`}>{children}</h2>
-                                                ),
-                                                h3: ({ children, value }) => (
-                                                    <h3 className={`text-xl font-semibold my-2 ${getTextAlignClassFromStyle(value?.style)}`}>{children}</h3>
-                                                ),
-                                                h3Center: ({ children, value }) => (
-                                                    <h3 className={`text-xl font-semibold my-2 ${getTextAlignClassFromStyle(value?.style)}`}>{children}</h3>
-                                                ),
-                                                h3Right: ({ children, value }) => (
-                                                    <h3 className={`text-xl font-semibold my-2 ${getTextAlignClassFromStyle(value?.style)}`}>{children}</h3>
-                                                ),
-                                                h3Justify: ({ children, value }) => (
-                                                    <h3 className={`text-xl font-semibold my-2 ${getTextAlignClassFromStyle(value?.style)}`}>{children}</h3>
-                                                ),
+                                                normal: ({ children }) => <p>{children}</p>,
+                                                h1: ({ children }) => <h1 className="text-3xl font-bold my-4">{children}</h1>,
+                                                h2: ({ children }) => <h2 className="text-2xl font-semibold my-3">{children}</h2>,
+                                                h3: ({ children }) => <h3 className="text-xl font-semibold my-2">{children}</h3>,
+                                                blockquote: ({ children }) => <blockquote>{children}</blockquote>,
+                                            },
+                                            marks: {
+                                                left: ({ children }) => <div className="text-left w-full">{children}</div>,
+                                                center: ({ children }) => <div className="text-center w-full">{children}</div>,
+                                                right: ({ children }) => <div className="text-right w-full">{children}</div>,
                                             },
                                             types: {
                                                 image: ({ value }) => (

--- a/src/sanity/schemaTypes/blockContent.js
+++ b/src/sanity/schemaTypes/blockContent.js
@@ -1,3 +1,5 @@
+import { AlignLeft, AlignCenter, AlignRight } from 'lucide-react'
+
 export default {
   title: 'Block Content',
   name: 'blockContent',
@@ -8,21 +10,9 @@ export default {
       type: 'block',
       styles: [
         { title: 'Normal', value: 'normal' },
-        { title: 'Normal (Center)', value: 'normalCenter' },
-        { title: 'Normal (Right)', value: 'normalRight' },
-        { title: 'Normal (Justify)', value: 'normalJustify' },
         { title: 'Heading 1', value: 'h1' },
-        { title: 'Heading 1 (Center)', value: 'h1Center' },
-        { title: 'Heading 1 (Right)', value: 'h1Right' },
-        { title: 'Heading 1 (Justify)', value: 'h1Justify' },
         { title: 'Heading 2', value: 'h2' },
-        { title: 'Heading 2 (Center)', value: 'h2Center' },
-        { title: 'Heading 2 (Right)', value: 'h2Right' },
-        { title: 'Heading 2 (Justify)', value: 'h2Justify' },
         { title: 'Heading 3', value: 'h3' },
-        { title: 'Heading 3 (Center)', value: 'h3Center' },
-        { title: 'Heading 3 (Right)', value: 'h3Right' },
-        { title: 'Heading 3 (Justify)', value: 'h3Justify' },
         { title: 'Quote', value: 'blockquote' },
       ],
       lists: [
@@ -34,6 +24,9 @@ export default {
           { title: 'Strong', value: 'strong' },
           { title: 'Emphasis', value: 'em' },
           { title: 'Code', value: 'code' },
+          { title: 'Left', value: 'left', icon: AlignLeft },
+          { title: 'Center', value: 'center', icon: AlignCenter },
+          { title: 'Right', value: 'right', icon: AlignRight },
         ],
         annotations: [
           {


### PR DESCRIPTION
### Motivation
- Move alignment responsibilities from numerous style variants to inline marks and simplify renderer logic for PortableText to make content alignment easier to manage and the codebase cleaner.

### Description
- Removed various style-based alignment helpers and style-specific block variants and replaced them with simplified `PortableText` block renderers for `normal`, `h1`, `h2`, `h3`, and `blockquote` in `NewsDetailPage` and `ProjectDetailPage`.
- Added `marks` handlers (`left`, `center`, `right`) to the `PortableText` render components so alignment is handled via marks instead of many style variants.
- Updated the Sanity `blockContent` schema to remove redundant centered/right/justify style variants and add `Left`, `Center`, and `Right` decorators with icons by importing `AlignLeft`, `AlignCenter`, and `AlignRight`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14002dc4fc8333838139252b2c1d0d)