### PR TITLE
Replace counter pings with icon badges and add alignment icons to blockContent schema

### DIFF
--- a/src/components/WhyChooseUs.js
+++ b/src/components/WhyChooseUs.js
@@ -1,6 +1,7 @@
 "use client";
 import React, {useState, useEffect} from 'react';
 import Image from "next/image";
+import {BadgeCheck, Palette, Users} from "lucide-react";
 import animateOnObserve from "@/lib/animateOnObserve";
 
 const WhyChooseUs = () => {
@@ -61,7 +62,9 @@ const WhyChooseUs = () => {
                 </div>
                 {/* Counter 1 - Top position */}
                 <div className="absolute -top-4 -right-27 md:-top-6 md:-right-36 flex items-center space-x-2 md:space-x-6">
-                    <div className="relative w-4 h-4 rounded-full bg-orange-400 ping"/>
+                    <div className="relative w-8 h-8 rounded-full bg-orange-400/15 border border-orange-300 flex items-center justify-center">
+                        <BadgeCheck className="w-4 h-4 text-orange-500"/>
+                    </div>
                     <div className="text-lg md:text-3xl font-bold text-orange-500 counter-trigger">
                         {counter1.toLocaleString()}+
                         <div className="text-[10px] md:text-sm text-gray-600 uppercase tracking-wide">
@@ -71,7 +74,9 @@ const WhyChooseUs = () => {
                 </div>
                 {/* Counter 2 - Middle position */}
                 <div className="absolute -right-40 md:-right-57 flex items-center space-x-2 md:space-x-5">
-                    <div className="relative w-4 h-4 rounded-full bg-orange-400 ping"/>
+                    <div className="relative w-8 h-8 rounded-full bg-orange-400/15 border border-orange-300 flex items-center justify-center">
+                        <Palette className="w-4 h-4 text-orange-500"/>
+                    </div>
                     <div className="text-lg md:text-3xl font-bold text-orange-500 counter-trigger">
                         <div className="mb-1 md:mb-2">{counter2.toLocaleString()}+</div>
                         <div className="text-[10px] md:text-sm text-gray-600 uppercase tracking-wide">
@@ -82,7 +87,9 @@ const WhyChooseUs = () => {
 
                 {/* Counter 3 - Bottom  position */}
                 <div className="absolute -bottom-4 -right-36 md:-bottom-6 md:-right-48 flex items-center space-x-2 md:space-x-5">
-                    <div className="relative w-4 h-4 rounded-full bg-orange-400 ping"/>
+                    <div className="relative w-8 h-8 rounded-full bg-orange-400/15 border border-orange-300 flex items-center justify-center">
+                        <Users className="w-4 h-4 text-orange-500"/>
+                    </div>
                     <div className="text-lg md:text-3xl font-bold text-orange-500 counter-trigger">
                         {counter3.toLocaleString()}+
                         <div className="text-[10px] md:text-sm text-gray-600 uppercase tracking-wide">

--- a/src/sanity/schemaTypes/blockContent.js
+++ b/src/sanity/schemaTypes/blockContent.js
@@ -1,3 +1,12 @@
+import React from 'react'
+import {AlignCenter, AlignLeft, AlignRight} from 'lucide-react'
+
+const LeftAlignMarkIcon = () => <AlignLeft size={14} strokeWidth={2} />
+
+const CenterAlignMarkIcon = () => <AlignCenter size={14} strokeWidth={2} />
+
+const RightAlignMarkIcon = () => <AlignRight size={14} strokeWidth={2} />
+
 export default {
   title: 'Block Content',
   name: 'blockContent',
@@ -7,41 +16,39 @@ export default {
       title: 'Block',
       type: 'block',
       styles: [
-        { title: 'Normal', value: 'normal' },
-        { title: 'Heading 1', value: 'h1' },
-        { title: 'Heading 2', value: 'h2' },
-        { title: 'Heading 3', value: 'h3' },
-        { title: 'Quote', value: 'blockquote' },
+        {title: 'Normal', value: 'normal'},
+        {title: 'Heading 1', value: 'h1'},
+        {title: 'Heading 2', value: 'h2'},
+        {title: 'Heading 3', value: 'h3'},
+        {title: 'Quote', value: 'blockquote'},
       ],
       lists: [
-        { title: 'Bullet', value: 'bullet' },
-        { title: 'Numbered', value: 'number' },
+        {title: 'Bullet', value: 'bullet'},
+        {title: 'Numbered', value: 'number'},
       ],
       marks: {
         decorators: [
-          { title: 'Strong', value: 'strong' },
-          { title: 'Emphasis', value: 'em' },
-          { title: 'Code', value: 'code' },
-          { title: 'Left', value: 'left' },
-          { title: 'Center', value: 'center' },
-          { title: 'Right', value: 'right' },
+          {title: 'Strong', value: 'strong'},
+          {title: 'Emphasis', value: 'em'},
+          {title: 'Code', value: 'code'},
+          {title: 'Left', value: 'left', icon: LeftAlignMarkIcon},
+          {title: 'Center', value: 'center', icon: CenterAlignMarkIcon},
+          {title: 'Right', value: 'right', icon: RightAlignMarkIcon},
         ],
         annotations: [
           {
             name: 'link',
             type: 'object',
             title: 'Link',
-            fields: [
-              { name: 'href', type: 'url', title: 'Url' },
-            ],
+            fields: [{name: 'href', type: 'url', title: 'Url'}],
           },
         ],
       },
     },
-    { type: 'table' },
+    {type: 'table'},
     {
       type: 'image',
-      options: { hotspot: true },
+      options: {hotspot: true},
       fields: [
         {
           name: 'alt',


### PR DESCRIPTION
### Motivation

- Improve the visual language of the `WhyChooseUs` counter by using recognizable icons instead of small ping dots to better convey meaning. 
- Enhance the Sanity `blockContent` editor by adding alignment icons for left/center/right decorators so editors have clearer UI affordances. 

### Description

- Updated `src/components/WhyChooseUs.js` to import `BadgeCheck`, `Palette`, and `Users` from `lucide-react` and replaced the small ping indicators with bordered circular badges that contain those icons. 
- Adjusted badge sizing and layout classes and preserved the existing counter animation behavior. 
- Updated `src/sanity/schemaTypes/blockContent.js` to import `AlignLeft`, `AlignCenter`, and `AlignRight` from `lucide-react`, added small functional components `LeftAlignMarkIcon`, `CenterAlignMarkIcon`, and `RightAlignMarkIcon`, and attached them to the `left`, `center`, and `right` decorators respectively. 
- Applied minor code formatting/consistency tweaks in `blockContent.js` (spacing and object formatting) and kept existing schema fields and options intact. 

### Testing

- Ran the project's linting and static checks (`npm run lint` / type checks) which completed successfully. 
- Built the frontend dev bundle (`npm run build`) locally to verify there were no compilation errors related to the new imports, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1411569248833385616ef65e878406)